### PR TITLE
update findbugs to 3.0.0 to allow build with java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>2.5.4</version>
+				<version>3.0.0</version>
 				<configuration>
 					<findbugsXmlOutput>true</findbugsXmlOutput>
 					<failOnError>false</failOnError>


### PR DESCRIPTION
without this build fails with "Unable to get XClass for java/lang/StringBuilder" ... due to findubs 2.5.4 not being compatible with java 8. With the change "mvn clean install" works fine.
