### PR TITLE
Fix build errors in my environment.

### DIFF
--- a/andmore-core/plugins/certmanager/plugin.xml
+++ b/andmore-core/plugins/certmanager/plugin.xml
@@ -255,7 +255,7 @@
          <objectContribution
             adaptable="false"
             id="org.eclipse.andmore.android.certmanager.core.ui.action.KeyStoreModel"
-            objectclass="org.eclipse.andmore.android.certmanager.ui.model.KeyStoreNode">
+            objectClass="org.eclipse.andmore.android.certmanager.ui.model.KeyStoreNode">
             <action
                   class="org.eclipse.andmore.android.certmanager.ui.action.PopupMenuActionDelegate"
                   definitionId="org.eclipse.andmore.android.certmanager.backup"

--- a/android-core/plugins/org.eclipse.andmore.package/.classpath
+++ b/android-core/plugins/org.eclipse.andmore.package/.classpath
@@ -2,6 +2,5 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
Not sure why they don't happen in others. An object contribution
attribute, objectClass, was spelled with the missing camel case.
Also in andmore.package, the src source folder doesn't exist so I
removed it.

Signed-off-by: Doug Schaefer <dschaefer@qnx.com>