### PR TITLE
[459407] Update README.md with link to project homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Contributing
 
-Andmore based off the open source plugins from MotoDev Studio and Android Development Tools.  This is a fork of those plugins.   The
-goal is to enhance the Google ADT plugins to provide additional features and functionality that ADT currently
+[Andmore](https://www.eclipse.org/andmore) is a fork of the former MotoDev Studio and Android Development Tools plugins for eclipse.
+The goal is to enhance the Google ADT plugins to provide additional features and functionality that ADT currently
 does not provide.
 
 This is an open source community lead project, so contributions are encouraged.  All code contributions will


### PR DESCRIPTION
Updated the README.md so that it has a link back to the
project homepage.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=459407
Signed-off-by: David Carver <d_a_carver@yahoo.com>