### PR TITLE
[457343] Rename log collector packages

### DIFF
--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/core/internal/CollectLogFile.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/core/internal/CollectLogFile.java
@@ -22,17 +22,16 @@ import java.util.List;
 
 import org.eclipse.andmore.android.common.utilities.FileUtil;
 import org.eclipse.andmore.android.logger.collector.core.ILogFile;
+import org.eclipse.andmore.android.logger.collector.util.LogCollectorExtensionLoader;
+import org.eclipse.andmore.android.logger.collector.util.LoggerCollectorConstants;
+import org.eclipse.andmore.android.logger.collector.util.LoggerCollectorMessages;
+import org.eclipse.andmore.android.logger.collector.util.PlatformException;
+import org.eclipse.andmore.android.logger.collector.util.ZipUtil;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.swt.widgets.TableItem;
-
-import com.motorola.studio.android.logger.collector.util.LogCollectorExtensionLoader;
-import com.motorola.studio.android.logger.collector.util.LoggerCollectorConstants;
-import com.motorola.studio.android.logger.collector.util.LoggerCollectorMessages;
-import com.motorola.studio.android.logger.collector.util.PlatformException;
-import com.motorola.studio.android.logger.collector.util.ZipUtil;
 
 /**
  * This class is responsible to manage all collecting log files requirements.

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/core/internal/EclipseLogFile.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/core/internal/EclipseLogFile.java
@@ -19,10 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.andmore.android.logger.collector.core.ILogFile;
+import org.eclipse.andmore.android.logger.collector.util.LoggerCollectorConstants;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
-
-import com.motorola.studio.android.logger.collector.util.LoggerCollectorConstants;
 
 /**
  * This class provides the Eclipse log file to the Log Files Collector feature

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/core/internal/EnvironmentLogFile.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/core/internal/EnvironmentLogFile.java
@@ -19,10 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.andmore.android.logger.collector.core.ILogFile;
+import org.eclipse.andmore.android.logger.collector.util.LoggerCollectorConstants;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
-
-import com.motorola.studio.android.logger.collector.util.LoggerCollectorConstants;
 
 /**
  * This class provides the environment log file to the log files collector

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/core/internal/StudioLogFile.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/core/internal/StudioLogFile.java
@@ -21,10 +21,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.andmore.android.logger.collector.core.ILogFile;
+import org.eclipse.andmore.android.logger.collector.util.LoggerCollectorConstants;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
-
-import com.motorola.studio.android.logger.collector.util.LoggerCollectorConstants;
 
 /**
  * This class provides the studio log files to the collect log files feature

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/ui/LogFileColumn.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/ui/LogFileColumn.java
@@ -13,13 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.motorola.studio.android.logger.collector.ui;
+package org.eclipse.andmore.android.logger.collector.ui;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.andmore.android.logger.collector.core.ILogFile;
 import org.eclipse.andmore.android.logger.collector.core.internal.CollectLogFile;
+import org.eclipse.andmore.android.logger.collector.util.LoggerCollectorMessages;
+import org.eclipse.andmore.android.logger.collector.util.PlatformException;
+import org.eclipse.andmore.android.logger.collector.util.WidgetsUtil;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.SWT;
@@ -31,10 +34,6 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
-
-import com.motorola.studio.android.logger.collector.util.LoggerCollectorMessages;
-import com.motorola.studio.android.logger.collector.util.PlatformException;
-import com.motorola.studio.android.logger.collector.util.WidgetsUtil;
 
 /**
  * This class visually represents a log file Table View.

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/ui/handler/LoggerCollectorHandler.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/ui/handler/LoggerCollectorHandler.java
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.motorola.studio.android.logger.collector.ui.handler;
+package org.eclipse.andmore.android.logger.collector.ui.handler;
 
+import org.eclipse.andmore.android.logger.collector.ui.wizard.LoggerCollectorWizard;
+import org.eclipse.andmore.android.logger.collector.util.WidgetsUtil;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-
-import com.motorola.studio.android.logger.collector.ui.wizard.LoggerCollectorWizard;
-import com.motorola.studio.android.logger.collector.util.WidgetsUtil;
 
 /**
  * This class is responsible to handling action in menu collect log file item.

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/ui/wizard/LoggerCollectorWizard.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/ui/wizard/LoggerCollectorWizard.java
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-package com.motorola.studio.android.logger.collector.ui.wizard;
+package org.eclipse.andmore.android.logger.collector.ui.wizard;
 
+import org.eclipse.andmore.android.logger.collector.util.LoggerCollectorConstants;
+import org.eclipse.andmore.android.logger.collector.util.LoggerCollectorMessages;
+import org.eclipse.andmore.android.logger.collector.util.PlatformException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.wizard.Wizard;
-
-import com.motorola.studio.android.logger.collector.util.LoggerCollectorConstants;
-import com.motorola.studio.android.logger.collector.util.LoggerCollectorMessages;
-import com.motorola.studio.android.logger.collector.util.PlatformException;
 
 /**
  * This class represents the logger collector wizard.

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/ui/wizard/LoggerCollectorWizardPage.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/ui/wizard/LoggerCollectorWizardPage.java
@@ -13,11 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.motorola.studio.android.logger.collector.ui.wizard;
+package org.eclipse.andmore.android.logger.collector.ui.wizard;
 
 import java.util.ArrayList;
 import java.util.Calendar;
 
+import org.eclipse.andmore.android.logger.collector.ui.LogFileColumn;
+import org.eclipse.andmore.android.logger.collector.util.LoggerCollectorConstants;
+import org.eclipse.andmore.android.logger.collector.util.LoggerCollectorMessages;
+import org.eclipse.andmore.android.logger.collector.util.WidgetsFactory;
+import org.eclipse.andmore.android.logger.collector.util.WidgetsUtil;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.preference.DirectoryFieldEditor;
@@ -35,12 +40,6 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.PlatformUI;
-
-import com.motorola.studio.android.logger.collector.ui.LogFileColumn;
-import com.motorola.studio.android.logger.collector.util.LoggerCollectorConstants;
-import com.motorola.studio.android.logger.collector.util.LoggerCollectorMessages;
-import com.motorola.studio.android.logger.collector.util.WidgetsFactory;
-import com.motorola.studio.android.logger.collector.util.WidgetsUtil;
 
 /**
  * This class contains the design of collect log files wizard page.

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/LogCollectorExtensionLoader.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/LogCollectorExtensionLoader.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.motorola.studio.android.logger.collector.util;
+package org.eclipse.andmore.android.logger.collector.util;
 
 import java.util.ArrayList;
 

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/LoggerCollectorConstants.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/LoggerCollectorConstants.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.motorola.studio.android.logger.collector.util;
+package org.eclipse.andmore.android.logger.collector.util;
 
 import java.io.File;
 

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/LoggerCollectorMessages.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/LoggerCollectorMessages.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.motorola.studio.android.logger.collector.util;
+package org.eclipse.andmore.android.logger.collector.util;
 
 import java.text.MessageFormat;
 import java.util.MissingResourceException;

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/PlatformException.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/PlatformException.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.motorola.studio.android.logger.collector.util;
+package org.eclipse.andmore.android.logger.collector.util;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/PlatformLogger.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/PlatformLogger.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.motorola.studio.android.logger.collector.util;
+package org.eclipse.andmore.android.logger.collector.util;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/WidgetsFactory.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/WidgetsFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.motorola.studio.android.logger.collector.util;
+package org.eclipse.andmore.android.logger.collector.util;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.swt.SWT;

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/WidgetsUtil.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/WidgetsUtil.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.motorola.studio.android.logger.collector.util;
+package org.eclipse.andmore.android.logger.collector.util;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/ZipUtil.java
+++ b/andmore-core/plugins/logger.collector/src/org/eclipse/andmore/android/logger/collector/util/ZipUtil.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.motorola.studio.android.logger.collector.util;
+package org.eclipse.andmore.android.logger.collector.util;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;


### PR DESCRIPTION
Log collector packages neede to be renamed to
the org.eclipse.andmore namespace.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=457343
Signed-off-by: David Carver <d_a_carver@yahoo.com>