### PR TITLE
[nobug] Fix Integration Tests so they run

### DIFF
--- a/android-core/.gitignore
+++ b/android-core/.gitignore
@@ -1,2 +1,3 @@
 *.iml
+*.orig
 plugins/*/*.target

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/pom.xml
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/pom.xml
@@ -13,9 +13,9 @@
 		<artifactId>andmore-core-parent</artifactId>
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
-	
+
 	<properties>
-		<os-jvm-flags>-Xms256m -Xmx512m -XX:MaxPermSize=256M</os-jvm-flags>
+		<os-jvm-flags>-Xms256m -Xmx1024m -XX:MaxPermSize=256M</os-jvm-flags>
 	</properties>
 
 
@@ -114,7 +114,7 @@
 					<skipTests>false</skipTests>
 					<testFailureIgnore>true</testFailureIgnore>
 					<useUIHarness>true</useUIHarness>
-					<forkedProcessTimeoutInSeconds>120</forkedProcessTimeoutInSeconds>
+					<appArgLine>-debug -console</appArgLine>
 					<argLine>${os-jvm-flags} ${tycho.testArgLine}</argLine>
 					<dependency-resolution>
 						<extraRequirements>
@@ -125,6 +125,33 @@
 							</requirement>
 						</extraRequirements>
 					</dependency-resolution>
+					<dependencies>
+					    <dependency>
+							<type>p2-installable-unit</type>
+							<artifactId>org.eclipse.andmore</artifactId>
+							<version>0.0.0</version>
+						</dependency>
+						<dependency>
+							<type>p2-installable-unit</type>
+							<artifactId>org.eclipse.sdk.ide</artifactId>
+							<version>0.0.0</version>
+						</dependency>
+						<dependency>
+							<type>p2-installable-unit</type>
+							<artifactId>org.eclipse.wst.xml.ui</artifactId>
+							<version>0.0.0</version>
+						</dependency>
+						<dependency>
+							<type>p2-installable-unit</type>
+							<artifactId>org.eclipse.wst.xsd.ui</artifactId>
+							<version>0.0.0</version>
+						</dependency>
+						<dependency>
+							<type>p2-installable-unit</type>
+							<artifactId>org.eclipse.wst.wsdl.ui</artifactId>
+							<version>0.0.0</version>
+						</dependency>
+					</dependencies>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/DefaultDialogProcessor.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/DefaultDialogProcessor.java
@@ -1,0 +1,44 @@
+package org.eclipse.andmore.integration.tests;
+
+
+import org.eclipse.jface.dialogs.DialogPage;
+import org.eclipse.jface.dialogs.ProgressMonitorDialog;
+import org.junit.Assert;
+
+public class DefaultDialogProcessor implements IDialogProcessor {
+
+	@Override
+	public void processDialog(Object dialog) {
+
+		/**
+		 * If this is a ProgressMonitorDialog, then ignore. The
+		 * ProgressMonitorDialog does not block the UI from running.
+		 */
+		if (dialog instanceof ProgressMonitorDialog) {
+			return;
+		}
+
+		System.out.println("Processing dialog: " + dialog.getClass().getName());
+
+		// Handle jface dialog
+		if (dialog instanceof org.eclipse.jface.dialogs.Dialog) {
+			org.eclipse.jface.dialogs.Dialog jfaceDialog = (org.eclipse.jface.dialogs.Dialog) dialog;
+			jfaceDialog.close();
+			return;
+		}
+
+		// Handle swt dialog
+		if (dialog instanceof org.eclipse.swt.widgets.Dialog) {
+			Assert.fail("org.eclipse.swt.widgets.Dialog is currently not supported");
+			return;
+		}
+
+		// Handle dialogPage. These are typically some sort of wizard
+		if (dialog instanceof DialogPage) {
+			Assert.fail("DialogPage is currently not supported");
+			return;
+		}
+
+	}
+
+}

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/DialogMonitor.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/DialogMonitor.java
@@ -1,0 +1,72 @@
+package org.eclipse.andmore.integration.tests;
+
+
+import org.eclipse.swt.widgets.Display;
+import org.junit.Assert;
+
+/**
+ * 
+ * @author ddodd
+ * 
+ *         The DialogMonitor is used to detect dialogs which appear during a UI
+ *         plugin unit tests. The IDialogProcessor can be customize different
+ *         types of dialogs. Once the test is over, the passed in IDialogProcess
+ *         can be used to query any information during the test.
+ * 
+ *         See DefaultDialogProcessor
+ * 
+ */
+public class DialogMonitor {
+
+	DialogMonitorJob m_dialogMonitorJob;
+
+	IDialogProcessor m_dialogProcessor;
+
+	boolean syncMode = true;// is in sync mode,default to true
+
+	public boolean isSyncMode() {
+		return syncMode;
+	}
+
+	public void setSyncMode(boolean syncMode) {
+		this.syncMode = syncMode;
+	}
+
+	/**
+	 * Create the default processor
+	 * 
+	 */
+	public DialogMonitor() {
+		m_dialogProcessor = new DefaultDialogProcessor();
+	}
+
+	public DialogMonitor(IDialogProcessor dialogProcessor) {
+		m_dialogProcessor = dialogProcessor;
+	}
+
+	/**
+	 * Fire up the thread and start looking for the dialog
+	 * 
+	 */
+	public void startMonitoring() {
+
+		final Display m_display = Display.getCurrent();
+
+		Assert.assertNotNull(m_display);
+
+		m_dialogMonitorJob = new DialogMonitorJob(m_display, m_dialogProcessor,
+				isSyncMode());
+		m_dialogMonitorJob.start();
+	}
+
+	/**
+	 * Tell the thread to stop.
+	 * 
+	 * @return
+	 */
+	public void stopMonitoring() {
+
+		m_dialogMonitorJob.setAllDone(true);
+
+	}
+}

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/DialogMonitorJob.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/DialogMonitorJob.java
@@ -1,0 +1,110 @@
+package org.eclipse.andmore.integration.tests;
+
+import org.eclipse.jface.dialogs.DialogPage;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+
+public class DialogMonitorJob extends Thread {
+
+	boolean m_allDone;
+
+	Display m_display;
+
+	IDialogProcessor m_dialogProcessor;
+
+	boolean isSyncMode = true;
+
+	public DialogMonitorJob(Display display, IDialogProcessor processor,
+			boolean isSyncMode) {
+		super("Monitoring Dialogs");
+		m_display = display;
+		m_dialogProcessor = processor;
+		this.isSyncMode = isSyncMode;
+	}
+
+	/**
+	 * Recursive method that crawls up the parents and looks for a dialog
+	 * 
+	 * @param compositeControl
+	 * @return
+	 */
+	private Object getDialog(Control compositeControl) {
+
+		if (compositeControl == null) {
+			return null;
+		}
+
+		Object data = compositeControl.getData();
+		if (data != null
+				&& (data instanceof org.eclipse.jface.dialogs.Dialog
+						|| data instanceof org.eclipse.swt.widgets.Dialog || data instanceof DialogPage)) {
+			return data;
+		}
+
+		return getDialog(compositeControl.getParent());
+	}
+
+	private void processDialog() {
+		Control control = m_display.getFocusControl();
+
+		if (control != null) {
+
+			Object dialogObject = getDialog(control);
+
+			if (dialogObject != null) {
+				m_dialogProcessor.processDialog(dialogObject);
+
+				UnitTestHelper.runEventQueue();
+			}
+		}
+
+	}
+
+	@Override
+	public void run() {
+		while (true) {
+
+			if (isSyncMode) {
+				m_display.syncExec(new Runnable() {
+
+					@Override
+					public void run() {
+						processDialog();
+					}
+
+				});
+
+			} else {
+				m_display.asyncExec(new Runnable() {
+
+					@Override
+					public void run() {
+						processDialog();
+					}
+
+				});
+			}
+
+			if (m_allDone) {
+				return;
+			}
+
+			/**
+			 * Give a little time for the task to run. We do not want to take up
+			 * all the CPU by just searching.
+			 */
+			try {
+				Thread.sleep(150);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+
+		}
+
+	}
+
+	public void setAllDone(boolean allDone) {
+		m_allDone = allDone;
+	}
+
+}

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/IDialogProcessor.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/IDialogProcessor.java
@@ -1,0 +1,9 @@
+package org.eclipse.andmore.integration.tests;
+
+public interface IDialogProcessor {
+
+	// This method is called to process the found dialog.
+	// The dialog is passed in as an Object because eclipse does not have
+	// one root dialog.
+	public void processDialog(Object dialog);
+}

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/IntegrationTestSuite.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/IntegrationTestSuite.java
@@ -1,0 +1,43 @@
+package org.eclipse.andmore.integration.tests;
+
+import org.eclipse.andmore.integration.tests.functests.sampleProjects.SampleProjectTest;
+import org.eclipse.andmore.internal.build.AaptParserTest;
+import org.eclipse.andmore.internal.build.AaptQuickFixTest;
+import org.eclipse.andmore.internal.editors.AndroidContentAssistTest;
+import org.eclipse.andmore.internal.editors.AndroidXmlAutoEditStrategyTest;
+import org.eclipse.andmore.internal.editors.AndroidXmlCharacterMatcherTest;
+import org.eclipse.andmore.internal.editors.HyperlinksTest;
+import org.eclipse.andmore.internal.editors.formatting.EclipseXmlPrettyPrinterTest;
+import org.eclipse.andmore.internal.editors.layout.gle2.LayoutMetadataTest;
+import org.eclipse.andmore.internal.editors.manifest.ManifestInfoTest;
+import org.eclipse.andmore.internal.launch.JUnitLaunchConfigDelegateTest;
+import org.eclipse.andmore.internal.lint.ProjectLintConfigurationTest;
+import org.eclipse.andmore.internal.refactorings.core.AndroidPackageRenameParticipantTest;
+import org.eclipse.andmore.internal.refactorings.core.RenameResourceParticipantTest;
+import org.eclipse.andmore.internal.refactorings.renamepackage.ApplicationPackageNameRefactoringTest;
+import org.eclipse.andmore.internal.wizards.exportgradle.ExportGradleTest;
+import org.eclipse.andmore.internal.wizards.templates.TemplateHandlerTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({SampleProjectTest.class,
+	AaptParserTest.class,
+	AaptQuickFixTest.class,
+	EclipseXmlPrettyPrinterTest.class,
+	AndroidContentAssistTest.class,
+	AndroidXmlAutoEditStrategyTest.class,
+	AndroidXmlCharacterMatcherTest.class,
+	HyperlinksTest.class,
+	LayoutMetadataTest.class,
+	ManifestInfoTest.class,
+	JUnitLaunchConfigDelegateTest.class,
+	ProjectLintConfigurationTest.class,
+	AndroidPackageRenameParticipantTest.class,
+	RenameResourceParticipantTest.class,
+	ApplicationPackageNameRefactoringTest.class,
+	ExportGradleTest.class,
+	TemplateHandlerTest.class})
+public class IntegrationTestSuite {
+
+}

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/SdkLoadingTestCase.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/SdkLoadingTestCase.java
@@ -17,17 +17,23 @@ package org.eclipse.andmore.integration.tests;
 
 import static org.junit.Assert.*;
 
+import java.io.File;
+
 import com.android.ide.common.sdk.LoadStatus;
 
 import org.eclipse.andmore.AdtPlugin;
+import org.eclipse.andmore.AdtPlugin.CheckSdkErrorHandler;
 import org.eclipse.andmore.internal.preferences.AdtPrefs;
 import org.eclipse.andmore.internal.sdk.AndroidTargetParser;
 import org.eclipse.andmore.internal.sdk.Sdk;
 
 import com.android.sdklib.IAndroidTarget;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.After;
+import org.junit.BeforeClass;
 
 /**
  * A test case which uses the SDK loaded by the ADT plugin.
@@ -35,14 +41,13 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 public abstract class SdkLoadingTestCase extends SdkTestCase {
 
 	private Sdk mSdk;
-
-	protected SdkLoadingTestCase() {
-	}
+		
 
 	/**
 	 * Retrieve the {@link Sdk} under test.
 	 */
 	protected Sdk getSdk() {
+		System.out.println("getSdk");
 		if (mSdk == null) {
 			mSdk = loadSdk();
 			assertNotNull(mSdk);
@@ -75,6 +80,7 @@ public abstract class SdkLoadingTestCase extends SdkTestCase {
 		assertTrue("No valid SDK installation is set; for tests you typically need to set the"
 				+ " environment variable ADT_TEST_SDK_PATH to point to an SDK folder", sdkLocation != null
 				&& sdkLocation.length() > 0);
+		AdtPrefs.getPrefs().setSdkLocation(new File(sdkLocation));
 
 		Object sdkLock = Sdk.getLock();
 		LoadStatus loadStatus = LoadStatus.LOADING;
@@ -96,9 +102,13 @@ public abstract class SdkLoadingTestCase extends SdkTestCase {
 			assertEquals(LoadStatus.LOADED, loadStatus);
 			sdk = Sdk.getCurrent();
 		}
+		
+		if (sdk.getTargets().length == 0) {
+			System.out.println("Did not find any valid targets. Reloading SDK from " + sdkLocation);
+			sdk = Sdk.loadSdk(sdkLocation);
+		}
 		assertNotNull(sdk);
-		return sdk;
-	}
+		return sdk;	}
 
 	protected boolean validateSdk(IAndroidTarget target) {
 		return true;

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/UnitTestHelper.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/UnitTestHelper.java
@@ -1,0 +1,117 @@
+package org.eclipse.andmore.integration.tests;
+
+import java.lang.reflect.Method;
+
+import org.eclipse.core.internal.resources.Workspace;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+
+@SuppressWarnings("rawtypes")
+public class UnitTestHelper {
+	public static void runParentJob(Job job) {
+		Class superClass = job.getClass().getSuperclass();
+		runJob(superClass, job);
+	}
+
+	public static void runJob(Job job) {
+		Class jobClass = job.getClass();
+		runJob(jobClass, job);
+	}
+
+	private static void runJob(Class jobClass, Job job) {
+		try {
+			jobClass.getName();
+			Method scheduleMethod = jobClass.getDeclaredMethod("run",
+					IProgressMonitor.class);
+			scheduleMethod.setAccessible(true);
+
+			scheduleMethod.invoke(job, new Object[] { null });
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+	}
+
+	public static void runEventQueue(int count, int sleepInterval) {
+
+		for (int counter = 0; counter < count; counter++) {
+			runEventQueue();
+			sleep(sleepInterval);
+		}
+	}
+
+	/**
+	 * Runs the event queue on the current display until it is empty.
+	 */
+	public static void runEventQueue() {
+		IWorkbenchWindow window = getActiveWorkbenchWindow();
+		if (window != null)
+			runEventQueue(window.getShell());
+	}
+
+	public static void runEventQueue(IWorkbenchPart part) {
+		if (part == null) {
+			return;
+		}
+		runEventQueue(part.getSite().getShell());
+	}
+
+	public static void runEventQueue(Shell shell) {
+		runEventQueue(shell.getDisplay());
+	}
+
+	public static void runEventQueue(Display display) {
+		while (display.readAndDispatch()) {
+			// Do nothing
+		}
+
+	}
+
+	public static void removeAllProjectFromWorkspace() {
+
+		Workspace m_workspace = (Workspace) ResourcesPlugin.getWorkspace();
+		IProject[] projects = m_workspace.getRoot().getProjects();
+
+		if (projects != null) {
+			try {
+
+				for (IProject project : projects) {
+					project.close(null);
+					project.delete(true, null);
+
+				}
+
+			} catch (CoreException e) {
+				// Who cares...
+			}
+
+		}
+	}
+
+	public static void sleep(int intervalTime) {
+		try {
+			Thread.sleep(intervalTime);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public static Display getActiveDisplay() {
+		IWorkbenchWindow window = getActiveWorkbenchWindow();
+		return window != null ? window.getShell().getDisplay() : null;
+	}
+
+	public static IWorkbenchWindow getActiveWorkbenchWindow() {
+		return PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+	}
+
+}

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/functests/layoutRendering/ApiDemosRenderingTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/functests/layoutRendering/ApiDemosRenderingTest.java
@@ -81,6 +81,7 @@ import java.util.Map;
 
 import javax.imageio.ImageIO;
 
+@Ignore
 public class ApiDemosRenderingTest extends SdkLoadingTestCase {
 
 	/**
@@ -179,7 +180,6 @@ public class ApiDemosRenderingTest extends SdkLoadingTestCase {
 	}
 
 	@Test
-	@Ignore
 	public void testApiDemos() throws IOException, XmlPullParserException {
 		findApiDemos();
 	}

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/build/AaptParserTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/build/AaptParserTest.java
@@ -33,9 +33,8 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
-@Ignore
 public class AaptParserTest extends AdtProjectTest {
-
+	
 	@Test
 	public void testBasic() throws Exception {
 		// Test the "at 'property' with value 'value' range matching included
@@ -70,6 +69,7 @@ public class AaptParserTest extends AdtProjectTest {
 	}
 
 	@Test
+	@Ignore
 	public void testRange3() throws Exception {
 		// Check that when we have a duplicate resource error, we highlight both
 		// the original

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/build/AaptQuickFixTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/build/AaptQuickFixTest.java
@@ -53,24 +53,21 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-@Ignore
 public class AaptQuickFixTest extends AdtProjectTest {
+	
 	@Override
-	protected boolean testCaseNeedsUniqueProject() {
-		// Make a separate test project for this test such that we don't pollute
-		// code assist
-		// tests with our new resources
+	protected boolean testNeedsUniqueProject() {
 		return true;
 	}
 
 	@Test
-	@Ignore("XMLUnit")
 	public void testQuickFix1() throws Exception {
 		// Test adding a value into an existing file (res/values/strings.xml)
 		checkResourceFix("quickfix1.xml", "android:text=\"@string/firs^tstring\"", "res/values/strings.xml");
 	}
 
 	@Test
+	@Ignore
 	public void testQuickFix2() throws Exception {
 		// Test adding a value into a new file (res/values/dimens.xml, will be
 		// created)
@@ -78,7 +75,7 @@ public class AaptQuickFixTest extends AdtProjectTest {
 	}
 
 	@Test
-	@Ignore("XMLUnit")
+	@Ignore
 	public void testQuickFix3() throws Exception {
 		// Test adding a file based resource (uses new file wizard machinery)
 		checkResourceFix("quickfix1.xml", "layout=\"@layout/^testlayout\"", "res/layout/testlayout.xml");

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/AndroidContentAssistTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/AndroidContentAssistTest.java
@@ -54,12 +54,11 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 @SuppressWarnings("javadoc")
-@Ignore
 public class AndroidContentAssistTest extends AdtProjectTest {
 	private static final String CARET = "^"; //$NON-NLS-1$
 
 	@Override
-	protected boolean testCaseNeedsUniqueProject() {
+	protected boolean testNeedsUniqueProject() {
 		return true;
 	}
 
@@ -177,6 +176,7 @@ public class AndroidContentAssistTest extends AdtProjectTest {
 	}
 
 	@Test
+	@Ignore
 	public void testCompletion10() throws Exception {
 		// Test completion of element names
 		checkLayoutCompletion("completion1.xml", "<T^extView");
@@ -199,6 +199,7 @@ public class AndroidContentAssistTest extends AdtProjectTest {
 	}
 
 	@Test
+	@Ignore("Dialog")
 	public void testCompletion13a() throws Exception {
 		checkLayoutCompletion("completion2.xml", "gravity=\"left|bottom|^cen");
 	}
@@ -562,12 +563,14 @@ public class AndroidContentAssistTest extends AdtProjectTest {
 	}
 
 	@Test
+	@Ignore
 	public void testCompletion71() throws Exception {
 		checkResourceCompletion("completionvalues2.xml",
 				"<item name=\"main_layout5\" type=\"string\">@string/^app_name</item>");
 	}
 
 	@Test
+	@Ignore
 	public void testCompletion72() throws Exception {
 		// Test completion of theme attributes
 		checkLayoutCompletion("completion11.xml", "?^android:attr/Textapp");

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/AndroidXmlAutoEditStrategyTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/AndroidXmlAutoEditStrategyTest.java
@@ -37,7 +37,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 @SuppressWarnings("javadoc")
-@Ignore
 public class AndroidXmlAutoEditStrategyTest extends AdtProjectTest {
 
 	public void checkInsertNewline(String before, String after) throws Exception {
@@ -105,17 +104,6 @@ public class AndroidXmlAutoEditStrategyTest extends AdtProjectTest {
 		return s.substring(0, index) + s.substring(index + 1);
 	}
 	
-	@Override
-	@Before
-	public void setUp() throws Exception {
-		// Make sure the workspace is clean.
-		IProject projects[] = ResourcesPlugin.getWorkspace().getRoot().getProjects();
-		for(IProject project : projects) {
-			project.delete(true, new NullProgressMonitor());
-		}
-		super.setUp();
-	}
-
 	@Test
 	public void testCornerCase1() throws Exception {
 		checkInsertNewline("^", "\n^");
@@ -169,6 +157,7 @@ public class AndroidXmlAutoEditStrategyTest extends AdtProjectTest {
 	}
 
 	@Test
+	@Ignore
 	public void testSplitAttribute() throws Exception {
 		checkInsertNewline("\n" + "    <newtag ^attribute='value'/>\n",
 

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/AndroidXmlCharacterMatcherTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/AndroidXmlCharacterMatcherTest.java
@@ -32,7 +32,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 @SuppressWarnings("restriction")
-@Ignore
 public class AndroidXmlCharacterMatcherTest extends AdtProjectTest {
 	@Test
 	public void testGotoMatchingFwd1() throws Exception {

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/HyperlinksTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/HyperlinksTest.java
@@ -50,12 +50,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 @SuppressWarnings({ "restriction", "javadoc" })
-@Ignore("SDK Location Failure")
+@Ignore
 public class HyperlinksTest extends AdtProjectTest {
-	@Override
-	protected boolean testCaseNeedsUniqueProject() {
-		return true;
-	}
 
 	@Test
 	public void testFqnRegexp() throws Exception {
@@ -97,6 +93,7 @@ public class HyperlinksTest extends AdtProjectTest {
 	}
 
 	@Test
+	@Ignore
 	public void testNavigate4() throws Exception {
 		// Check navigating to resource with many resolutions
 		checkXmlNavigation("navigation1.xml", "res/layout/navigation1.xml", "android:text=\"@android:st^ring/ok\"");
@@ -126,6 +123,7 @@ public class HyperlinksTest extends AdtProjectTest {
 	}
 
 	@Test
+	@Ignore
 	public void testNavigate8() throws Exception {
 		// Check navigating to a resource inside text content where there is
 		// space around

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/formatting/EclipseXmlPrettyPrinterTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/formatting/EclipseXmlPrettyPrinterTest.java
@@ -15,6 +15,8 @@
  */
 package org.eclipse.andmore.internal.editors.formatting;
 
+import static org.junit.Assert.*;
+
 import com.android.ide.common.xml.XmlFormatStyle;
 
 import org.eclipse.andmore.internal.editors.formatting.EclipseXmlFormatPreferences;
@@ -24,16 +26,16 @@ import org.eclipse.andmore.internal.preferences.AdtPrefs;
 import org.eclipse.jface.preference.PreferenceStore;
 import org.eclipse.wst.sse.core.internal.provisional.IStructuredModel;
 import org.eclipse.wst.xml.core.internal.provisional.document.IDOMModel;
+import org.junit.Before;
+import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import junit.framework.TestCase;
 
 @SuppressWarnings({ "javadoc", "restriction" })
-public class EclipseXmlPrettyPrinterTest extends TestCase {
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+public class EclipseXmlPrettyPrinterTest {
+	@Before
+	public void setUp() throws Exception {
 		PreferenceStore store = new PreferenceStore();
 		AdtPrefs.init(store);
 		AdtPrefs prefs = AdtPrefs.getPrefs();
@@ -124,18 +126,21 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 		checkFormat(prefs, baseLocation, xml, expected);
 	}
 
+	@Test
 	public void testLayout1() throws Exception {
 		checkFormat("res/layout-port/layout1.xml", "<LinearLayout><Button></Button></LinearLayout>",
 
 		"<LinearLayout>\n" + "\n" + "    <Button>\n" + "    </Button>\n" + "\n" + "</LinearLayout>");
 	}
 
+	@Test
 	public void testLayout2() throws Exception {
 		checkFormat("res/layout-port/layout2.xml", "<LinearLayout><Button foo=\"bar\"></Button></LinearLayout>",
 
 		"<LinearLayout>\n" + "\n" + "    <Button foo=\"bar\" >\n" + "    </Button>\n" + "\n" + "</LinearLayout>");
 	}
 
+	@Test
 	public void testLayout3() throws Exception {
 		EclipseXmlFormatPreferences prefs = EclipseXmlFormatPreferences.create();
 		prefs.oneAttributeOnFirstLine = true;
@@ -144,6 +149,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 		"<LinearLayout>\n" + "\n" + "    <Button foo=\"bar\" >\n" + "    </Button>\n" + "\n" + "</LinearLayout>");
 	}
 
+	@Test
 	public void testClosedElements() throws Exception {
 		checkFormat("res/values/strings.xml", "<resources>\n" + "<item   name=\"title_container\"  type=\"id\"   />\n"
 				+ "<item name=\"title_logo\" type=\"id\"/>\n" + "</resources>\n",
@@ -152,11 +158,13 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "    <item name=\"title_logo\" type=\"id\"/>\n" + "\n" + "</resources>\n");
 	}
 
+	@Test
 	public void testResources() throws Exception {
 		checkFormat("res/values-us/strings.xml", "<resources><item name=\"foo\">Text value here </item></resources>",
 				"<resources>\n\n" + "    <item name=\"foo\">Text value here </item>\n" + "\n</resources>");
 	}
 
+	@Test
 	public void testNodeTypes() throws Exception {
 		// Ensures that a document with all kinds of node types is serialized
 		// correctly
@@ -183,6 +191,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "<!-- Type <key>less-than</key> (&#x3C;) -->\n" + "\n" + "</LinearLayout>");
 	}
 
+	@Test
 	public void testWindowsDelimiters() throws Exception {
 		checkFormat(EclipseXmlFormatPreferences.create(), "res/layout-xlarge/layout.xml",
 				"<LinearLayout><Button foo=\"bar\"></Button></LinearLayout>",
@@ -191,6 +200,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 						+ "</LinearLayout>", "\r\n");
 	}
 
+	@Test
 	public void testRemoveBlanklines() throws Exception {
 		EclipseXmlFormatPreferences prefs = EclipseXmlFormatPreferences.create();
 		prefs.removeEmptyLines = true;
@@ -202,6 +212,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 						+ "        <baz12>\n" + "        </baz12>\n" + "    </bar3>\n" + "</foo>");
 	}
 
+	@Test
 	public void testRange() throws Exception {
 		checkFormat(EclipseXmlFormatPreferences.create(), "res/layout-xlarge/layout.xml",
 				"<LinearLayout><Button foo=\"bar\"></Button><CheckBox/></LinearLayout>", "\n"
@@ -209,6 +220,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				"Button", false, "CheckBox");
 	}
 
+	@Test
 	public void testOpenTagOnly() throws Exception {
 		checkFormat(EclipseXmlFormatPreferences.create(), "res/layout-xlarge/layout.xml",
 				"<LinearLayout><Button foo=\"bar\"></Button><CheckBox/></LinearLayout>", "\n"
@@ -217,6 +229,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				"Button", true, "Button");
 	}
 
+	@Test
 	public void testRange2() throws Exception {
 		EclipseXmlFormatPreferences prefs = EclipseXmlFormatPreferences.create();
 		prefs.removeEmptyLines = true;
@@ -228,6 +241,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 						+ "        </baz12>\n", "\n", "baz1", false, "baz12");
 	}
 
+	@Test
 	public void testEOLcomments() throws Exception {
 		checkFormat("res/drawable-mdpi/states.xml",
 				"<selector xmlns:android=\"http://schemas.android.com/apk/res/android\">\n"
@@ -242,6 +256,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 						+ "    <item android:color=\"#ff000000\"/> <!-- default -->\n" + "\n" + "</selector>");
 	}
 
+	@Test
 	public void testFormatColorList() throws Exception {
 		checkFormat("res/drawable-hdpi/states.xml",
 				"<selector xmlns:android=\"http://schemas.android.com/apk/res/android\">\n"
@@ -252,6 +267,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 						+ "    <item android:color=\"#777777\"/> <!-- not selected -->\n" + "\n" + "</selector>");
 	}
 
+	@Test
 	public void testPreserveNewlineAfterComment() throws Exception {
 		checkFormat("res/values/dimen.xml", "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
 				+ "<resources><dimen name=\"colorstrip_height\">6dip</dimen>\n"
@@ -270,6 +286,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "    <dimen name=\"text_size_large\">22sp</dimen>\n" + "\n" + "</resources>");
 	}
 
+	@Test
 	public void testPlurals() throws Exception {
 		checkFormat(
 				"res/values-us/strings.xml",
@@ -293,6 +310,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 						+ "    </plurals>\n" + "\n" + "</resources>");
 	}
 
+	@Test
 	public void testMultiAttributeResource() throws Exception {
 		checkFormat(
 				"res/values-us/strings.xml",
@@ -303,6 +321,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 						+ "\n" + "</resources>");
 	}
 
+	@Test
 	public void testMultilineCommentAlignment() throws Exception {
 		checkFormat("res/values-us/strings.xml", "<resources>"
 				+ "    <!-- Deprecated strings - Move the identifiers to this section, mark as DO NOT TRANSLATE,\n"
@@ -316,6 +335,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "    <string name=\"meeting_invitation\"></string>\n" + "\n" + "</resources>");
 	}
 
+	@Test
 	public void testLineCommentSpacing() throws Exception {
 		checkFormat("res/values-us/strings.xml", "<resources>\n" + "\n"
 				+ "    <dimen name=\"colorstrip_height\">6dip</dimen>\n" + "    <!-- comment1 -->\n"
@@ -335,6 +355,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "    <dimen name=\"text_size_large\">22sp</dimen>\n" + "\n" + "</resources>");
 	}
 
+	@Test
 	public void testCommentHandling() throws Exception {
 		checkFormat(EclipseXmlFormatPreferences.create(), "res/layout/layout1.xml", "<foo >\n" + "\n"
 				+ "    <!-- abc\n" + "         def\n" + "         ghi -->\n" + "\n" + "    <!-- abc\n" + "    def\n"
@@ -345,6 +366,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "    <!--\n" + "abc\n" + "def\n" + "ghi\n" + "    -->\n" + "\n" + "</foo>");
 	}
 
+	@Test
 	public void testCommentHandling2() throws Exception {
 		checkFormat(EclipseXmlFormatPreferences.create(), "res/layout-xlarge/layout.xml", "<foo >\n"
 				+ "    <!-- multi -->\n" + "\n" + "    <bar />\n" + "</foo>",
@@ -352,6 +374,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 		"<foo>\n" + "\n" + "    <!-- multi -->\n" + "\n" + "    <bar />\n" + "\n" + "</foo>");
 	}
 
+	@Test
 	public void testMenus1() throws Exception {
 		checkFormat(EclipseXmlFormatPreferences.create(), "res/menu/menu1.xml",
 		// http://code.google.com/p/android/issues/detail?id=21383
@@ -390,6 +413,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 						+ "        </menu>\n" + "    </item>\n" + "\n" + "</menu>");
 	}
 
+	@Test
 	public void testMenus2() throws Exception {
 		EclipseXmlFormatPreferences prefs = EclipseXmlFormatPreferences.create();
 		prefs.removeEmptyLines = true;
@@ -421,6 +445,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 						+ "    </item>\n" + "</layer-list>");
 	}
 
+	@Test
 	public void testMenus3() throws Exception {
 		checkFormat(EclipseXmlFormatPreferences.create(), "res/menu/menu1.xml",
 		// http://code.google.com/p/android/issues/detail?id=21227
@@ -446,6 +471,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 
 	}
 
+	@Test
 	public void testColors1() throws Exception {
 		checkFormat(EclipseXmlFormatPreferences.create(), "res/values/colors.xml", "<resources>\n"
 				+ "  <color name=\"enrollment_error\">#99e21f14</color>\n" + "\n"
@@ -455,6 +481,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "    <color name=\"service_starting_up\">#99000000</color>\n" + "\n" + "</resources>");
 	}
 
+	@Test
 	public void testEclipseFormatStyle1() throws Exception {
 		EclipseXmlFormatPreferences prefs = new EclipseXmlFormatPreferences() {
 			@Override
@@ -475,6 +502,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "\t<color name=\"service_starting_up\">#99000000</color>\n" + "\n" + "</resources>");
 	}
 
+	@Test
 	public void testEclipseFormatStyle2() throws Exception {
 		EclipseXmlFormatPreferences prefs = new EclipseXmlFormatPreferences() {
 			@Override
@@ -496,6 +524,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "  <color name=\"service_starting_up\">#99000000</color>\n" + "\n" + "</resources>");
 	}
 
+	@Test
 	public void testNameSorting() throws Exception {
 		checkFormat("res/values/dimen.xml", "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + "<resources>\n"
 				+ "    <attr format=\"integer\" name=\"no\" />\n" + "</resources>",
@@ -504,6 +533,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "    <attr name=\"no\" format=\"integer\" />\n" + "\n" + "</resources>");
 	}
 
+	@Test
 	public void testStableText() throws Exception {
 		checkFormat("res/layout/stable.xml", "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
 				+ "<LinearLayout xmlns:android=\"http://schemas.android.com/apk/res/android\"\n"
@@ -516,6 +546,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "    android:orientation=\"vertical\" >\n" + "    Hello World\n" + "\n" + "</LinearLayout>");
 	}
 
+	@Test
 	public void testResources1() throws Exception {
 		checkFormat("res/values/strings.xml", "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + "<resources>\n" + "\n"
 				+ "        <string name=\"test_string\">a\n" + "                </string>\n" + "\n" + "</resources>",
@@ -524,6 +555,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "    <string name=\"test_string\">a</string>\n" + "\n" + "</resources>");
 	}
 
+	@Test
 	public void testMarkup() throws Exception {
 		checkFormat("res/values/strings.xml", "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + "<resources>\n" + "\n"
 				+ "<string name=\"welcome\">Welcome to <b>Android</b>!</string>"
@@ -538,6 +570,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "\n" + "</resources>");
 	}
 
+	@Test
 	public void testPreserveEntities() throws Exception {
 		// Ensure that entities such as &gt; in the input string are preserved
 		// in the output
@@ -553,6 +586,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "    <string name=\"untitled3\">&apos;untitled3&quot;</string>\n" + "\n" + "</resources>\n");
 	}
 
+	@Test
 	public void testCData1() throws Exception {
 		checkFormat("res/values/strings.xml", "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + "<resources>\n"
 				+ "    <string name=\"foo\"><![CDATA[bar]]></string>\n" + "</resources>",
@@ -561,6 +595,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "    <string name=\"foo\"><![CDATA[bar]]></string>\n" + "\n" + "</resources>");
 	}
 
+	@Test
 	public void testCData2() throws Exception {
 		checkFormat("res/values/strings.xml", "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + "<resources>\n"
 				+ "    <string name=\"foo1\"><![CDATA[bar1\n" + "bar2\n" + "bar3]]></string>\n"
@@ -571,6 +606,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "    <string name=\"foo2\"><![CDATA[bar]]></string>\n" + "\n" + "</resources>");
 	}
 
+	@Test
 	public void testComplexString() throws Exception {
 		checkFormat("res/values/strings.xml", "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + "<resources>\n"
 				+ "<string name=\"progress_completed_export_all\">The database has "
@@ -583,6 +619,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "\\\"<i>%s</i>\\\"</font></string>\n" + "\n" + "</resources>");
 	}
 
+	@Test
 	public void test52887() throws Exception {
 		// https://code.google.com/p/android/issues/detail?id=52887
 		checkFormat("res/layout/relative.xml",
@@ -594,6 +631,7 @@ public class EclipseXmlPrettyPrinterTest extends TestCase {
 				+ "    android:layout_width=\"match_parent\"\n" + "    android:layout_height=\"match_parent\" />\n");
 	}
 
+	@Test
 	public void testPreserveLastNewline() throws Exception {
 		checkFormat("res/values/strings.xml", "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + "<resources>\n"
 				+ "<string name=\"progress_completed_export_all\">The database has "

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/ChangeLayoutRefactoringTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/ChangeLayoutRefactoringTest.java
@@ -32,9 +32,8 @@ import java.util.Collections;
 import java.util.List;
 
 @SuppressWarnings("javadoc")
-@Ignore
 public class ChangeLayoutRefactoringTest extends RefactoringTest {
-
+	
 	@Test
 	public void testChangeLayout1a() throws Exception {
 		// Test a basic layout which performs some nesting -- tests basic grid
@@ -89,6 +88,7 @@ public class ChangeLayoutRefactoringTest extends RefactoringTest {
 	}
 
 	@Test
+	@Ignore
 	public void testGridLayout2() throws Exception {
 		// Test code which analyzes an embedded RelativeLayout
 		checkRefactoring(FQCN_GRID_LAYOUT, "sample2.xml", true);
@@ -101,11 +101,13 @@ public class ChangeLayoutRefactoringTest extends RefactoringTest {
 	}
 
 	@Test
+	@Ignore
 	public void testConvertToGrid() throws Exception {
 		checkRefactoring(FQCN_GRID_LAYOUT, "sample9.xml", true);
 	}
 
 	@Test
+	@Ignore
 	public void testConvertFromGrid() throws Exception {
 		checkRefactoring(FQCN_LINEAR_LAYOUT, "sample10.xml", true);
 	}
@@ -115,11 +117,13 @@ public class ChangeLayoutRefactoringTest extends RefactoringTest {
 	}
 
 	@Test
+	@Ignore
 	public void testInitialAttributes() throws Exception {
 		checkRefactoring(FQCN_LINEAR_LAYOUT, "sample10.xml", true, "android:orientation=vertical");
 	}
 
 	@Test
+	@Ignore
 	public void testInsertSpacer() throws Exception {
 		checkRefactoring(FQCN_GRID_LAYOUT, "sample11.xml", true);
 	}

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/ChangeViewRefactoringTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/ChangeViewRefactoringTest.java
@@ -31,13 +31,12 @@ import java.util.List;
 public class ChangeViewRefactoringTest extends RefactoringTest {
 
 	@Test
-	@Ignore
 	public void testChangeView1() throws Exception {
 		checkRefactoring("sample1a.xml", FQCN_RADIO_BUTTON, "@+id/button1", "@+id/button6");
 	}
 
 	@Test
-	@Ignore("XMLUnit")
+	@Ignore
 	public void testChangeView2() throws Exception {
 		// Tests (1) updating references to the renamed id of the changed
 		// widgets

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/ExtractIncludeRefactoringTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/ExtractIncludeRefactoringTest.java
@@ -35,7 +35,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@Ignore
 public class ExtractIncludeRefactoringTest extends RefactoringTest {
 
 	@Override
@@ -43,12 +42,6 @@ public class ExtractIncludeRefactoringTest extends RefactoringTest {
 		return false;
 	}
 
-	@Override
-	protected boolean testCaseNeedsUniqueProject() {
-		// Because some of these tests look at ALL layouts in the project
-		// to identify matches
-		return true;
-	}
 
 	@Test
 	public void testExtract1() throws Exception {

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/ExtractStyleRefactoringTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/ExtractStyleRefactoringTest.java
@@ -47,10 +47,6 @@ import java.util.Set;
 
 @Ignore
 public class ExtractStyleRefactoringTest extends RefactoringTest {
-	@Override
-	protected boolean testCaseNeedsUniqueProject() {
-		return true;
-	}
 
 	@Test
 	public void testExtract1() throws Exception {
@@ -81,6 +77,7 @@ public class ExtractStyleRefactoringTest extends RefactoringTest {
 	}
 
 	@Test
+	@Ignore("Dialog screen pops up")
 	public void testExtract2() throws Exception {
 		getTestDataFile(getProject(), "navigationstyles.xml", "res/values/navigationstyles.xml");
 
@@ -100,6 +97,7 @@ public class ExtractStyleRefactoringTest extends RefactoringTest {
 	// manually)
 	// but the DOM model returns null when run in a test context.
 	@Test
+	@Ignore
 	public void testExtract4() throws Exception {
 		// Test extracting on a single caret position over an attribute: Should
 		// extract
@@ -109,6 +107,7 @@ public class ExtractStyleRefactoringTest extends RefactoringTest {
 	}
 
 	@Test
+	@Ignore
 	public void testExtract5() throws Exception {
 		// Test extracting on a range selection inside an element: should
 		// extract just
@@ -127,6 +126,7 @@ public class ExtractStyleRefactoringTest extends RefactoringTest {
 	}
 
 	@Test
+	@Ignore
 	public void testExtract7() throws Exception {
 		// Verify that even with a different namespace prefix we end up with
 		// android:

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/RefactoringTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/RefactoringTest.java
@@ -58,7 +58,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @SuppressWarnings("restriction")
-@Ignore
 public abstract class RefactoringTest extends AdtProjectTest {
 
 	protected boolean autoFormat() {

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/UnwrapRefactoringTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/UnwrapRefactoringTest.java
@@ -27,7 +27,6 @@ import org.w3c.dom.Element;
 
 import java.util.List;
 
-@Ignore("XMLUnit")
 public class UnwrapRefactoringTest extends RefactoringTest {
 
 	@Test

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/UseCompoundDrawableRefactoringTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/UseCompoundDrawableRefactoringTest.java
@@ -30,8 +30,8 @@ import org.w3c.dom.Element;
 import java.util.List;
 
 @SuppressWarnings("javadoc")
-@Ignore
 public class UseCompoundDrawableRefactoringTest extends RefactoringTest {
+	
 	@Test
 	public void testCombine() throws Exception {
 		assertNull(combine(null, null));
@@ -51,30 +51,35 @@ public class UseCompoundDrawableRefactoringTest extends RefactoringTest {
 	}
 
 	@Test
+	@Ignore
 	public void test1() throws Exception {
 		// Test converting an image above a text view
 		checkRefactoring("refactoring/usecompound/compound1.xml", "@+id/layout1");
 	}
 
 	@Test
+	@Ignore
 	public void test2() throws Exception {
 		// Test converting an image below a text view
 		checkRefactoring("refactoring/usecompound/compound2.xml", "@+id/layout2");
 	}
 
 	@Test
+	@Ignore
 	public void test3() throws Exception {
 		// Test converting an image to the left of a text view
 		checkRefactoring("refactoring/usecompound/compound3.xml", "@+id/layout3");
 	}
 
 	@Test
+	@Ignore
 	public void test4() throws Exception {
 		// Test converting an image to the right of a text view
 		checkRefactoring("refactoring/usecompound/compound4.xml", "@+id/layout4");
 	}
 
 	@Test
+	@Ignore
 	public void test5() throws Exception {
 		// Test converting an image where the LinearLayout is referenced (in a
 		// relative layout)
@@ -83,6 +88,7 @@ public class UseCompoundDrawableRefactoringTest extends RefactoringTest {
 	}
 
 	@Test
+	@Ignore
 	public void test6() throws Exception {
 		// Test converting an image where the LinearLayout is referenced (in a
 		// relative layout)
@@ -91,18 +97,21 @@ public class UseCompoundDrawableRefactoringTest extends RefactoringTest {
 	}
 
 	@Test
+	@Ignore
 	public void test7() throws Exception {
 		// Test converting where a namespace needs to be migrated
 		checkRefactoring("refactoring/usecompound/compound5.xml", "@+id/layout");
 	}
 
 	@Test
+	@Ignore
 	public void test8() throws Exception {
 		// Test padding handling
 		checkRefactoring("refactoring/usecompound/compound6.xml", "@+id/layout1");
 	}
 
 	@Test
+	@Ignore
 	public void test9() throws Exception {
 		// Test margin combination
 		checkRefactoring("refactoring/usecompound/compound7.xml", "@+id/layout1");

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/WrapInRefactoringTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/layout/refactoring/WrapInRefactoringTest.java
@@ -28,7 +28,6 @@ import org.w3c.dom.Element;
 
 import java.util.List;
 
-@Ignore("XMLUnit")
 public class WrapInRefactoringTest extends RefactoringTest {
 
 	@Test

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/manifest/ManifestInfoTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/editors/manifest/ManifestInfoTest.java
@@ -46,12 +46,7 @@ import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings("javadoc")
-@Ignore
 public class ManifestInfoTest extends AdtProjectTest {
-	@Override
-	protected boolean testCaseNeedsUniqueProject() {
-		return true;
-	}
 
 	@Test
 	public void testGetActivityThemes1() throws Exception {

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/launch/JUnitLaunchConfigDelegateTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/launch/JUnitLaunchConfigDelegateTest.java
@@ -16,19 +16,23 @@
 
 package org.eclipse.andmore.internal.launch;
 
+import static org.junit.Assert.*;
+
 import java.io.IOException;
 import java.util.Arrays;
 
 import org.eclipse.andmore.internal.launch.JUnitLaunchConfigDelegate;
+import org.junit.Test;
 
-import junit.framework.TestCase;
 
-public class JUnitLaunchConfigDelegateTest extends TestCase {
+public class JUnitLaunchConfigDelegateTest {
 
+	@Test
 	public void testAbleToFetchJunitJar() throws IOException {
 		assertTrue(JUnitLaunchConfigDelegate.getJunitJarLocation().endsWith("junit.jar"));
 	}
 
+	@Test
 	public void testFixBootpathExtWithAndroidJar() {
 		String[][] testArray = { null, {}, { "android.jar" }, null, { "some_other_jar.jar" }, };
 
@@ -37,6 +41,7 @@ public class JUnitLaunchConfigDelegateTest extends TestCase {
 		assertEqualsArrays(expectedArray, JUnitLaunchConfigDelegate.fixBootpathExt(testArray));
 	}
 
+	@Test
 	public void testFixBootpathExtWithNoAndroidJar() {
 		String[][] testArray = { null, { "somejar.jar" }, null, };
 
@@ -45,6 +50,7 @@ public class JUnitLaunchConfigDelegateTest extends TestCase {
 		assertEqualsArrays(expectedArray, JUnitLaunchConfigDelegate.fixBootpathExt(testArray));
 	}
 
+	@Test
 	public void testFixClasspathWithJunitJar() throws IOException {
 		String[] testArray = { JUnitLaunchConfigDelegate.getJunitJarLocation(), };
 
@@ -53,6 +59,7 @@ public class JUnitLaunchConfigDelegateTest extends TestCase {
 		assertEqualsArrays(expectedArray, JUnitLaunchConfigDelegate.fixClasspath(testArray, "test"));
 	}
 
+	@Test
 	public void testFixClasspathWithoutJunitJar() throws IOException {
 		String[] testArray = { "random.jar", };
 
@@ -61,6 +68,7 @@ public class JUnitLaunchConfigDelegateTest extends TestCase {
 		assertEqualsArrays(expectedArray, JUnitLaunchConfigDelegate.fixClasspath(testArray, "test"));
 	}
 
+	@Test
 	public void testFixClasspathWithNoJars() throws IOException {
 		String[] testArray = {};
 

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/lint/ProjectLintConfigurationTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/lint/ProjectLintConfigurationTest.java
@@ -39,7 +39,6 @@ import org.junit.Test;
 import java.io.File;
 
 @SuppressWarnings("javadoc")
-@Ignore
 public class ProjectLintConfigurationTest extends AdtProjectTest {
 
 	@Test
@@ -192,7 +191,7 @@ public class ProjectLintConfigurationTest extends AdtProjectTest {
 
 	@Override
 	protected File getTargetDir() {
-		File targetDir = new File(getTempDir(), getClass().getSimpleName() + "_" + name.getMethodName());
+		File targetDir = new File(getTempDir(), getClass().getSimpleName() + "_" + testName.getMethodName());
 		addCleanupDir(targetDir);
 		return targetDir;
 	}

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/refactorings/core/AndroidPackageRenameParticipantTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/refactorings/core/AndroidPackageRenameParticipantTest.java
@@ -35,10 +35,10 @@ import org.junit.Test;
  * TODO: Test renaming a DIFFERENT package than the application package!
  */
 @SuppressWarnings({ "javadoc", "restriction" })
-@Ignore
+@Ignore("Error Dialog when run as part of Test Suite.")
 public class AndroidPackageRenameParticipantTest extends RefactoringTestBase {
+
 	@Test
-	@Ignore
 	public void testRefactor1() throws Exception {
 		renamePackage(TEST_PROJECT, false /* renameSubpackages */, true /* updateReferences */, "my.pkg.name",
 

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/refactorings/core/RefactoringTestBase.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/refactorings/core/RefactoringTestBase.java
@@ -64,6 +64,7 @@ public abstract class RefactoringTestBase extends AdtProjectTest {
 	@Before
 	public void setUp() throws Exception {
 		// Not calling super.setUp
+		super.startMonitoringJob();
 	}
 
 	protected void checkRefactoring(Refactoring refactoring, String expected, @Nullable String expectedWarnings)
@@ -107,7 +108,7 @@ public abstract class RefactoringTestBase extends AdtProjectTest {
 	}
 
 	protected IProject createProject(Object[] testData) throws Exception {
-		String name = super.name.getMethodName();
+		String name = super.testName.getMethodName();
 		IProject project = createProject(name);
 		mProject = project;
 		File projectDir = AdtUtils.getAbsolutePath(project).toFile();

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/refactorings/core/RenameResourceParticipantTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/refactorings/core/RenameResourceParticipantTest.java
@@ -37,7 +37,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 @SuppressWarnings({ "javadoc", "restriction" })
-@Ignore
 public class RenameResourceParticipantTest extends RefactoringTestBase {
 	@Test
 	public void testRefactor1() throws Exception {

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/refactorings/renamepackage/ApplicationPackageNameRefactoringTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/refactorings/renamepackage/ApplicationPackageNameRefactoringTest.java
@@ -28,8 +28,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 @SuppressWarnings("javadoc")
-@Ignore
 public class ApplicationPackageNameRefactoringTest extends RefactoringTestBase {
+
 	@Test
 	public void testRefactor1() throws Exception {
 		renamePackage(TEST_PROJECT, "my.pkg.name",

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/wizards/exportgradle/ExportGradleTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/wizards/exportgradle/ExportGradleTest.java
@@ -65,13 +65,7 @@ public class ExportGradleTest extends AdtProjectTest {
 		mLastThrown = null;
 	}
 
-	@Override
-	protected boolean testCaseNeedsUniqueProject() {
-		return true;
-	}
-
 	@Test
-	@Ignore
 	public void testSimpleAndroidApp() throws Throwable {
 		IProject project = getProject("simple-app");
 		final IJavaProject javaProject = BaseProjectHelper.getJavaProject(project);
@@ -118,7 +112,6 @@ public class ExportGradleTest extends AdtProjectTest {
 	}
 
 	@Test
-	@Ignore
 	public void testSimpleAndroidLib() throws Throwable {
 		final IProject project = getProject("simple-library");
 		ProjectState projectState = Sdk.getProjectState(project.getProject());
@@ -174,7 +167,6 @@ public class ExportGradleTest extends AdtProjectTest {
 	}
 
 	@Test
-	@Ignore
 	public void testPlainJavaProject() throws Throwable {
 		IProject project = getJavaProject("simple-java");
 		final IJavaProject javaProject = BaseProjectHelper.getJavaProject(project);
@@ -212,7 +204,7 @@ public class ExportGradleTest extends AdtProjectTest {
 	protected IProject getProject(String projectName) {
 		IProject project = createProject(projectName);
 		assertNotNull(project);
-		if (!testCaseNeedsUniqueProject() && !testNeedsUniqueProject()) {
+		if (!testNeedsUniqueProject()) {
 			addCleanupDir(AdtUtils.getAbsolutePath(project).toFile());
 		}
 		addCleanupDir(project.getFullPath().toFile());
@@ -222,7 +214,7 @@ public class ExportGradleTest extends AdtProjectTest {
 	protected IProject getJavaProject(String projectName) {
 		IProject project = createJavaProject(projectName);
 		assertNotNull(project);
-		if (!testCaseNeedsUniqueProject() && !testNeedsUniqueProject()) {
+		if (!testNeedsUniqueProject()) {
 			addCleanupDir(AdtUtils.getAbsolutePath(project).toFile());
 		}
 		addCleanupDir(project.getFullPath().toFile());

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/wizards/templates/TemplateHandlerTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/wizards/templates/TemplateHandlerTest.java
@@ -72,6 +72,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -97,7 +98,7 @@ import java.util.Set;
  * multiple instances of the templates (to look for resource conflicts)
  */
 @SuppressWarnings("javadoc")
-@Ignore
+@Ignore("Causing garbage collection issues in JVM.")
 public class TemplateHandlerTest extends SdkLoadingTestCase {
 	/**
 	 * Flag used to quickly check each template once (for one version), to get
@@ -129,6 +130,13 @@ public class TemplateHandlerTest extends SdkLoadingTestCase {
 	@Before
 	public void setUp() throws Exception {
 		mApiSensitiveTemplate = true;
+	}
+	
+	@After
+	public void deleteProjects() throws Exception {
+		if (project != null) {
+			project.delete(true, true, new NullProgressMonitor());
+		}
 	}
 
 	/**
@@ -245,6 +253,7 @@ public class TemplateHandlerTest extends SdkLoadingTestCase {
 	}
 
 	@Test
+	@Ignore
 	public void testCreateRemainingTemplates() throws Exception {
 		sCount = 0;
 		long begin = System.currentTimeMillis();
@@ -667,6 +676,8 @@ public class TemplateHandlerTest extends SdkLoadingTestCase {
 		}
 	}
 
+	IProject project;
+	
 	private void checkProject(@NonNull NewProjectWizardState projectValues,
 			@Nullable NewTemplateWizardState templateValues) throws Exception {
 		NewTemplateWizardState values = projectValues.createActivity ? projectValues.activityValues : templateValues;
@@ -687,7 +698,7 @@ public class TemplateHandlerTest extends SdkLoadingTestCase {
 		projectValues.projectLocation = projectLocation;
 
 		// Create project with the given parameter map
-		final IProject project = createProject(projectValues);
+		project = createProject(projectValues);
 		assertNotNull(project);
 
 		if (templateValues != null) {

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/unittests/org/eclipse/andmore/internal/editors/formatting/AndroidXmlFormattingStrategyTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/unittests/org/eclipse/andmore/internal/editors/formatting/AndroidXmlFormattingStrategyTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.*;
 
 import com.android.ide.common.xml.XmlFormatPreferences;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.eclipse.andmore.test.utils.XMLAssert.assertXMLEqual;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -28,7 +28,6 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.text.edits.MalformedTreeException;
 import org.eclipse.text.edits.ReplaceEdit;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/unittests/org/eclipse/andmore/test/utils/XMLAssert.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/unittests/org/eclipse/andmore/test/utils/XMLAssert.java
@@ -1,0 +1,1121 @@
+/*
+ ******************************************************************
+Copyright (c) 2001-2007,2011 Jeff Martin, Tim Bacon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+ * Neither the name of the xmlunit.sourceforge.net nor the names
+      of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+ ******************************************************************
+ */
+
+// Original code from XML Unit updated to work with JUnit 4 assertions.
+// ported by David Carver.
+
+package org.eclipse.andmore.test.utils;
+
+import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.NodeTest;
+import org.custommonkey.xmlunit.NodeTestException;
+import org.custommonkey.xmlunit.NodeTester;
+import org.custommonkey.xmlunit.Validator;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.custommonkey.xmlunit.XSLTConstants;
+import org.custommonkey.xmlunit.XpathEngine;
+import org.custommonkey.xmlunit.exceptions.ConfigurationException;
+import org.custommonkey.xmlunit.exceptions.XpathException;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+
+import javax.xml.parsers.DocumentBuilder;
+
+import org.junit.Assert;
+import org.junit.Assert.*;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * Collection of static methods so that XML assertion facilities are available
+ * in any class, not just test suites. Thanks to Andrew McCormick and others for
+ * suggesting this refactoring.<br/>
+ * Available assertion methods are:
+ * <ul>
+ * <li><strong><code>assertXMLEqual</code></strong><br/>
+ * assert that two pieces of XML markup are <i>similar</i></li>
+ * <li><strong><code>assertXMLNotEqual</code></strong><br/>
+ * assert that two pieces of XML markup are <i>different</i></li>
+ * <li><strong><code>assertXMLIdentical</code></strong><br/>
+ * assert that two pieces of XML markup are <i>identical</i>. In most cases this
+ * assertion is too strong and <code>assertXMLEqual</code> is sufficient</li>
+ * <li><strong><code>assertXpathExists</code></strong><br/>
+ * assert that an XPath expression matches at least one node</li>
+ * <li><strong><code>assertXpathNotExists</code></strong><br/>
+ * assert that an XPath expression does not match any nodes</li>
+ * <li><strong><code>assertXpathsEqual</code></strong><br/>
+ * assert that the nodes obtained by executing two Xpaths are <i>similar</i></li>
+ * <li><strong><code>assertXpathsNotEqual</code></strong><br/>
+ * assert that the nodes obtained by executing two Xpaths are <i>different</i></li>
+ * <li><strong><code>assertXpathValuesEqual</code></strong><br/>
+ * assert that the flattened String obtained by executing two Xpaths are
+ * <i>similar</i></li>
+ * <li><strong><code>assertXpathValuesNotEqual</code></strong><br/>
+ * assert that the flattened String obtained by executing two Xpaths are
+ * <i>different</i></li>
+ * <li><strong><code>assertXpathEvaluatesTo</code></strong><br/>
+ * assert that the flattened String obtained by executing an Xpath is a
+ * particular value</li>
+ * <li><strong><code>assertXMLValid</code></strong><br/>
+ * assert that a piece of XML markup is valid with respect to a DTD: either by
+ * using the markup's own DTD or a different DTD</li>
+ * <li><strong><code>assertNodeTestPasses</code></strong><br/>
+ * assert that a piece of XML markup passes a {@link NodeTest NodeTest}</li>
+ * </ul>
+ * All underlying similarity and difference testing is done using {@link Diff
+ * Diff} instances which can be instantiated and evaluated independently of this
+ * class.
+ * 
+ * @see Diff#similar()
+ * @see Diff#identical() <br />
+ *      Examples and more at <a
+ *      href="http://xmlunit.sourceforge.net"/>xmlunit.sourceforge.net</a>
+ */
+public class XMLAssert extends Assert implements XSLTConstants {
+
+	protected XMLAssert() {
+		super();
+	}
+
+	/**
+	 * Assert that the result of an XML comparison is or is not similar.
+	 * 
+	 * @param diff
+	 *            the result of an XML comparison
+	 * @param assertion
+	 *            true if asserting that result is similar
+	 */
+	public static void assertXMLEqual(Diff diff, boolean assertion) {
+		assertXMLEqual(null, diff, assertion);
+	}
+
+	/**
+	 * Assert that the result of an XML comparison is or is not similar.
+	 * 
+	 * @param msg
+	 *            additional message to display if assertion fails
+	 * @param diff
+	 *            the result of an XML comparison
+	 * @param assertion
+	 *            true if asserting that result is similar
+	 */
+	public static void assertXMLEqual(String msg, Diff diff, boolean assertion) {
+		if (assertion != diff.similar()) {
+			fail(getFailMessage(msg, diff));
+		}
+	}
+
+	private static String getFailMessage(String msg, Diff diff) {
+		StringBuffer sb = new StringBuffer();
+		if (msg != null && msg.length() > 0) {
+			sb.append(msg).append(", ");
+		}
+		return sb.append(diff.toString()).toString();
+	}
+
+	/**
+	 * Assert that the result of an XML comparison is or is not identical
+	 * 
+	 * @param diff
+	 *            the result of an XML comparison
+	 * @param assertion
+	 *            true if asserting that result is identical
+	 */
+	public static void assertXMLIdentical(Diff diff, boolean assertion) {
+		assertXMLIdentical(null, diff, assertion);
+	}
+
+	/**
+	 * Assert that the result of an XML comparison is or is not identical
+	 * 
+	 * @param msg
+	 *            Message to display if assertion fails
+	 * @param diff
+	 *            the result of an XML comparison
+	 * @param assertion
+	 *            true if asserting that result is identical
+	 */
+	public static void assertXMLIdentical(String msg, Diff diff, boolean assertion) {
+		if (assertion != diff.identical()) {
+			fail(getFailMessage(msg, diff));
+		}
+	}
+
+	/**
+	 * Assert that two XML documents are similar
+	 * 
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXMLEqual(InputSource control, InputSource test) throws SAXException, IOException {
+		assertXMLEqual(null, control, test);
+	}
+
+	/**
+	 * Assert that two XML documents are similar
+	 * 
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXMLEqual(String control, String test) throws SAXException, IOException {
+		assertXMLEqual(null, control, test);
+	}
+
+	/**
+	 * Assert that two XML documents are similar
+	 * 
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 */
+	public static void assertXMLEqual(Document control, Document test) {
+		assertXMLEqual(null, control, test);
+	}
+
+	/**
+	 * Assert that two XML documents are similar
+	 * 
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXMLEqual(Reader control, Reader test) throws SAXException, IOException {
+		assertXMLEqual(null, control, test);
+	}
+
+	/**
+	 * Assert that two XML documents are similar
+	 * 
+	 * @param err
+	 *            Message to be displayed on assertion failure
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXMLEqual(String err, InputSource control, InputSource test) throws SAXException,
+			IOException {
+		Diff diff = new Diff(control, test);
+		assertXMLEqual(err, diff, true);
+	}
+
+	/**
+	 * Assert that two XML documents are similar
+	 * 
+	 * @param err
+	 *            Message to be displayed on assertion failure
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXMLEqual(String err, String control, String test) throws SAXException, IOException {
+		Diff diff = new Diff(control, test);
+		assertXMLEqual(err, diff, true);
+	}
+
+	/**
+	 * Assert that two XML documents are similar
+	 * 
+	 * @param err
+	 *            Message to be displayed on assertion failure
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 */
+	public static void assertXMLEqual(String err, Document control, Document test) {
+		Diff diff = new Diff(control, test);
+		assertXMLEqual(err, diff, true);
+	}
+
+	/**
+	 * Assert that two XML documents are similar
+	 * 
+	 * @param err
+	 *            Message to be displayed on assertion failure
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXMLEqual(String err, Reader control, Reader test) throws SAXException, IOException {
+		Diff diff = new Diff(control, test);
+		assertXMLEqual(err, diff, true);
+	}
+
+	/**
+	 * Assert that two XML documents are NOT similar
+	 * 
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXMLNotEqual(InputSource control, InputSource test) throws SAXException, IOException {
+		assertXMLNotEqual(null, control, test);
+	}
+
+	/**
+	 * Assert that two XML documents are NOT similar
+	 * 
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXMLNotEqual(String control, String test) throws SAXException, IOException {
+		assertXMLNotEqual(null, control, test);
+	}
+
+	/**
+	 * Assert that two XML documents are NOT similar
+	 * 
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 */
+	public static void assertXMLNotEqual(Document control, Document test) {
+		assertXMLNotEqual(null, control, test);
+	}
+
+	/**
+	 * Assert that two XML documents are NOT similar
+	 * 
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXMLNotEqual(Reader control, Reader test) throws SAXException, IOException {
+		assertXMLNotEqual(null, control, test);
+	}
+
+	/**
+	 * Assert that two XML documents are NOT similar
+	 * 
+	 * @param err
+	 *            Message to be displayed on assertion failure
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXMLNotEqual(String err, InputSource control, InputSource test) throws SAXException,
+			IOException {
+		Diff diff = new Diff(control, test);
+		assertXMLEqual(err, diff, false);
+	}
+
+	/**
+	 * Assert that two XML documents are NOT similar
+	 * 
+	 * @param err
+	 *            Message to be displayed on assertion failure
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXMLNotEqual(String err, String control, String test) throws SAXException, IOException {
+		Diff diff = new Diff(control, test);
+		assertXMLEqual(err, diff, false);
+	}
+
+	/**
+	 * Assert that two XML documents are NOT similar
+	 * 
+	 * @param err
+	 *            Message to be displayed on assertion failure
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 */
+	public static void assertXMLNotEqual(String err, Document control, Document test) {
+		Diff diff = new Diff(control, test);
+		assertXMLEqual(err, diff, false);
+	}
+
+	/**
+	 * Assert that two XML documents are NOT similar
+	 * 
+	 * @param err
+	 *            Message to be displayed on assertion failure
+	 * @param control
+	 *            XML to be compared against
+	 * @param test
+	 *            XML to be tested
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXMLNotEqual(String err, Reader control, Reader test) throws SAXException, IOException {
+		Diff diff = new Diff(control, test);
+		assertXMLEqual(err, diff, false);
+	}
+
+	/**
+	 * Assert that the node lists of two Xpaths in the same document are equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param document
+	 * @see XpathEngine
+	 */
+	public static void assertXpathsEqual(String controlXpath, String testXpath, Document document)
+			throws XpathException {
+		assertXpathsEqual(controlXpath, document, testXpath, document);
+	}
+
+	/**
+	 * Assert that the node lists of two Xpaths in the same document are equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param document
+	 * @see XpathEngine
+	 */
+	public static void assertXpathsEqual(String controlXpath, String testXpath, InputSource document)
+			throws SAXException, IOException, XpathException {
+		assertXpathsEqual(controlXpath, testXpath, XMLUnit.buildControlDocument(document));
+	}
+
+	/**
+	 * Assert that the node lists of two Xpaths in the same XML string are equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param inXMLString
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXpathsEqual(String controlXpath, String testXpath, String inXMLString)
+			throws SAXException, IOException, XpathException {
+		assertXpathsEqual(controlXpath, testXpath, XMLUnit.buildControlDocument(inXMLString));
+	}
+
+	/**
+	 * Assert that the node lists of two Xpaths in two documents are equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param controlDocument
+	 * @param testDocument
+	 * @see XpathEngine
+	 */
+	public static void assertXpathsEqual(String controlXpath, InputSource controlDocument, String testXpath,
+			InputSource testDocument) throws SAXException, IOException, XpathException {
+		assertXpathsEqual(controlXpath, XMLUnit.buildControlDocument(controlDocument), testXpath,
+				XMLUnit.buildTestDocument(testDocument));
+	}
+
+	/**
+	 * Assert that the node lists of two Xpaths in two XML strings are equal
+	 * 
+	 * @param xpathOne
+	 * @param inControlXMLString
+	 * @param xpathTwo
+	 * @param inTestXMLString
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXpathsEqual(String controlXpath, String inControlXMLString, String testXpath,
+			String inTestXMLString) throws SAXException, IOException, XpathException {
+		assertXpathsEqual(controlXpath, XMLUnit.buildControlDocument(inControlXMLString), testXpath,
+				XMLUnit.buildTestDocument(inTestXMLString));
+	}
+
+	/**
+	 * Assert that the node lists of two Xpaths in two documents are equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param controlDocument
+	 * @param testDocument
+	 * @see XpathEngine
+	 */
+	public static void assertXpathsEqual(String controlXpath, Document controlDocument, String testXpath,
+			Document testDocument) throws XpathException {
+		assertXpathEquality(controlXpath, controlDocument, testXpath, testDocument, true);
+	}
+
+	/**
+	 * Assert that the node lists of two Xpaths in the same document are NOT
+	 * equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param document
+	 * @see XpathEngine
+	 */
+	public static void assertXpathsNotEqual(String controlXpath, String testXpath, Document document)
+			throws XpathException {
+		assertXpathsNotEqual(controlXpath, document, testXpath, document);
+	}
+
+	/**
+	 * Assert that the node lists of two Xpaths in the same document are NOT
+	 * equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param document
+	 * @see XpathEngine
+	 */
+	public static void assertXpathsNotEqual(String controlXpath, String testXpath, InputSource document)
+			throws SAXException, IOException, XpathException {
+		assertXpathsNotEqual(controlXpath, testXpath, XMLUnit.buildControlDocument(document));
+	}
+
+	/**
+	 * Assert that the node lists of two Xpaths in the same XML string are NOT
+	 * equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param inXMLString
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXpathsNotEqual(String controlXpath, String testXpath, String inXMLString)
+			throws SAXException, IOException, XpathException {
+		assertXpathsNotEqual(controlXpath, testXpath, XMLUnit.buildControlDocument(inXMLString));
+	}
+
+	/**
+	 * Assert that the node lists of two Xpaths in two XML strings are NOT equal
+	 * 
+	 * @param xpathOne
+	 * @param inControlXMLString
+	 * @param xpathTwo
+	 * @param inTestXMLString
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXpathsNotEqual(String controlXpath, String inControlXMLString, String testXpath,
+			String inTestXMLString) throws SAXException, IOException, XpathException {
+		assertXpathsNotEqual(controlXpath, XMLUnit.buildControlDocument(inControlXMLString), testXpath,
+				XMLUnit.buildTestDocument(inTestXMLString));
+	}
+
+	/**
+	 * Assert that the node lists of two Xpaths in two XML strings are NOT equal
+	 * 
+	 * @param xpathOne
+	 * @param controlDocument
+	 * @param xpathTwo
+	 * @param testDocument
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXpathsNotEqual(String controlXpath, InputSource controlDocument, String testXpath,
+			InputSource testDocument) throws SAXException, IOException, XpathException {
+		assertXpathsNotEqual(controlXpath, XMLUnit.buildControlDocument(controlDocument), testXpath,
+				XMLUnit.buildTestDocument(testDocument));
+	}
+
+	/**
+	 * Assert that the node lists of two Xpaths in two documents are NOT equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param document
+	 * @see XpathEngine
+	 */
+	public static void assertXpathsNotEqual(String controlXpath, Document controlDocument, String testXpath,
+			Document testDocument) throws XpathException {
+		assertXpathEquality(controlXpath, controlDocument, testXpath, testDocument, false);
+	}
+
+	/**
+	 * Assert that the node lists of two Xpaths in two documents are equal or
+	 * not.
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param document
+	 * @param equality
+	 *            whether the values should be equal.
+	 * @see XpathEngine
+	 */
+	private static void assertXpathEquality(String controlXpath, Document controlDocument, String testXpath,
+			Document testDocument, boolean equal) throws XpathException {
+		XpathEngine xpath = XMLUnit.newXpathEngine();
+		Diff diff = new Diff(asXpathResultDocument(XMLUnit.newControlParser(),
+				xpath.getMatchingNodes(controlXpath, controlDocument)), asXpathResultDocument(XMLUnit.newTestParser(),
+				xpath.getMatchingNodes(testXpath, testDocument)));
+		assertXMLEqual(diff, equal);
+	}
+
+	/**
+	 * Assert that the evaluation of two Xpaths in the same document are equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param document
+	 * @see XpathEngine
+	 */
+	public static void assertXpathValuesEqual(String controlXpath, String testXpath, Document document)
+			throws XpathException {
+		assertXpathValuesEqual(controlXpath, document, testXpath, document);
+	}
+
+	/**
+	 * Assert that the evaluation of two Xpaths in the same XML string are equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param document
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXpathValuesEqual(String controlXpath, String testXpath, InputSource document)
+			throws SAXException, IOException, XpathException {
+		assertXpathValuesEqual(controlXpath, testXpath, XMLUnit.buildControlDocument(document));
+	}
+
+	/**
+	 * Assert that the evaluation of two Xpaths in the same XML string are equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param inXMLString
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXpathValuesEqual(String controlXpath, String testXpath, String inXMLString)
+			throws SAXException, IOException, XpathException {
+		assertXpathValuesEqual(controlXpath, testXpath, XMLUnit.buildControlDocument(inXMLString));
+	}
+
+	/**
+	 * Assert that the evaluation of two Xpaths in two XML strings are equal
+	 * 
+	 * @param xpathOne
+	 * @param control
+	 * @param xpathTwo
+	 * @param test
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXpathValuesEqual(String controlXpath, InputSource control, String testXpath,
+			InputSource test) throws SAXException, IOException, XpathException {
+		assertXpathValuesEqual(controlXpath, XMLUnit.buildControlDocument(control), testXpath,
+				XMLUnit.buildTestDocument(test));
+	}
+
+	/**
+	 * Assert that the evaluation of two Xpaths in two XML strings are equal
+	 * 
+	 * @param xpathOne
+	 * @param inControlXMLString
+	 * @param xpathTwo
+	 * @param inTestXMLString
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXpathValuesEqual(String controlXpath, String inControlXMLString, String testXpath,
+			String inTestXMLString) throws SAXException, IOException, XpathException {
+		assertXpathValuesEqual(controlXpath, XMLUnit.buildControlDocument(inControlXMLString), testXpath,
+				XMLUnit.buildTestDocument(inTestXMLString));
+	}
+
+	/**
+	 * Assert that the evaluation of two Xpaths in two documents are equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param document
+	 * @see XpathEngine
+	 */
+	public static void assertXpathValuesEqual(String controlXpath, Document controlDocument, String testXpath,
+			Document testDocument) throws XpathException {
+		XpathEngine xpath = XMLUnit.newXpathEngine();
+		assertEquals(xpath.evaluate(controlXpath, controlDocument), xpath.evaluate(testXpath, testDocument));
+	}
+
+	/**
+	 * Assert that the evaluation of two Xpaths in the same XML string are NOT
+	 * equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param control
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXpathValuesNotEqual(String controlXpath, String testXpath, InputSource control)
+			throws SAXException, IOException, XpathException {
+		assertXpathValuesNotEqual(controlXpath, testXpath, XMLUnit.buildControlDocument(control));
+	}
+
+	/**
+	 * Assert that the evaluation of two Xpaths in the same XML string are NOT
+	 * equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param inXMLString
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXpathValuesNotEqual(String controlXpath, String testXpath, String inXMLString)
+			throws SAXException, IOException, XpathException {
+		assertXpathValuesNotEqual(controlXpath, testXpath, XMLUnit.buildControlDocument(inXMLString));
+	}
+
+	/**
+	 * Assert that the evaluation of two Xpaths in the same document are NOT
+	 * equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param document
+	 */
+	public static void assertXpathValuesNotEqual(String controlXpath, String testXpath, Document document)
+			throws XpathException {
+		assertXpathValuesNotEqual(controlXpath, document, testXpath, document);
+	}
+
+	/**
+	 * Assert that the evaluation of two Xpaths in two XML strings are NOT equal
+	 * 
+	 * @param xpathOne
+	 * @param control
+	 * @param xpathTwo
+	 * @param test
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXpathValuesNotEqual(String controlXpath, InputSource control, String testXpath,
+			InputSource test) throws SAXException, IOException, XpathException {
+		assertXpathValuesNotEqual(controlXpath, XMLUnit.buildControlDocument(control), testXpath,
+				XMLUnit.buildTestDocument(test));
+	}
+
+	/**
+	 * Assert that the evaluation of two Xpaths in two XML strings are NOT equal
+	 * 
+	 * @param xpathOne
+	 * @param inControlXMLString
+	 * @param xpathTwo
+	 * @param inTestXMLString
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	public static void assertXpathValuesNotEqual(String controlXpath, String inControlXMLString, String testXpath,
+			String inTestXMLString) throws SAXException, IOException, XpathException {
+		assertXpathValuesNotEqual(controlXpath, XMLUnit.buildControlDocument(inControlXMLString), testXpath,
+				XMLUnit.buildTestDocument(inTestXMLString));
+	}
+
+	/**
+	 * Assert that the evaluation of two Xpaths in two documents are NOT equal
+	 * 
+	 * @param xpathOne
+	 * @param xpathTwo
+	 * @param document
+	 */
+	public static void assertXpathValuesNotEqual(String controlXpath, Document controlDocument, String testXpath,
+			Document testDocument) throws XpathException {
+		XpathEngine xpath = XMLUnit.newXpathEngine();
+		String control = xpath.evaluate(controlXpath, controlDocument);
+		String test = xpath.evaluate(testXpath, testDocument);
+		if (control != null) {
+			if (control.equals(test)) {
+				fail("Expected test value NOT to be equal to control but both were " + test);
+			}
+		} else if (test != null) {
+			fail("control xPath evaluated to empty node set, " + "but test xPath evaluated to " + test);
+		}
+	}
+
+	/**
+	 * Assert the value of an Xpath expression in an XML document.
+	 * 
+	 * @param expectedValue
+	 * @param xpathExpression
+	 * @param control
+	 * @throws SAXException
+	 * @throws IOException
+	 * @see XpathEngine which provides the underlying evaluation mechanism
+	 */
+	public static void assertXpathEvaluatesTo(String expectedValue, String xpathExpression, InputSource control)
+			throws SAXException, IOException, XpathException {
+		Document document = XMLUnit.buildControlDocument(control);
+		assertXpathEvaluatesTo(expectedValue, xpathExpression, document);
+	}
+
+	/**
+	 * Assert the value of an Xpath expression in an XML String
+	 * 
+	 * @param expectedValue
+	 * @param xpathExpression
+	 * @param inXMLString
+	 * @throws SAXException
+	 * @throws IOException
+	 * @see XpathEngine which provides the underlying evaluation mechanism
+	 */
+	public static void assertXpathEvaluatesTo(String expectedValue, String xpathExpression, String inXMLString)
+			throws SAXException, IOException, XpathException {
+		Document document = XMLUnit.buildControlDocument(inXMLString);
+		assertXpathEvaluatesTo(expectedValue, xpathExpression, document);
+	}
+
+	/**
+	 * Assert the value of an Xpath expression in an DOM Document
+	 * 
+	 * @param expectedValue
+	 * @param xpathExpression
+	 * @param inDocument
+	 * @see XpathEngine which provides the underlying evaluation mechanism
+	 */
+	public static void assertXpathEvaluatesTo(String expectedValue, String xpathExpression, Document inDocument)
+			throws XpathException {
+		XpathEngine simpleXpathEngine = XMLUnit.newXpathEngine();
+		assertEquals(expectedValue, simpleXpathEngine.evaluate(xpathExpression, inDocument));
+	}
+
+	/**
+	 * Assert that a specific XPath exists in some given XML
+	 * 
+	 * @param inXpathExpression
+	 * @param control
+	 * @see XpathEngine which provides the underlying evaluation mechanism
+	 */
+	public static void assertXpathExists(String xPathExpression, InputSource control) throws IOException, SAXException,
+			XpathException {
+		Document inDocument = XMLUnit.buildControlDocument(control);
+		assertXpathExists(xPathExpression, inDocument);
+	}
+
+	/**
+	 * Assert that a specific XPath exists in some given XML
+	 * 
+	 * @param inXpathExpression
+	 * @param inXMLString
+	 * @see XpathEngine which provides the underlying evaluation mechanism
+	 */
+	public static void assertXpathExists(String xPathExpression, String inXMLString) throws IOException, SAXException,
+			XpathException {
+		Document inDocument = XMLUnit.buildControlDocument(inXMLString);
+		assertXpathExists(xPathExpression, inDocument);
+	}
+
+	/**
+	 * Assert that a specific XPath exists in some given XML
+	 * 
+	 * @param inXpathExpression
+	 * @param inDocument
+	 * @see XpathEngine which provides the underlying evaluation mechanism
+	 */
+	public static void assertXpathExists(String xPathExpression, Document inDocument) throws XpathException {
+		XpathEngine simpleXpathEngine = XMLUnit.newXpathEngine();
+		NodeList nodeList = simpleXpathEngine.getMatchingNodes(xPathExpression, inDocument);
+		int matches = nodeList.getLength();
+		assertTrue("Expecting to find matches for Xpath " + xPathExpression, matches > 0);
+	}
+
+	/**
+	 * Assert that a specific XPath does NOT exist in some given XML
+	 * 
+	 * @param inXpathExpression
+	 * @param control
+	 * @see XpathEngine which provides the underlying evaluation mechanism
+	 */
+	public static void assertXpathNotExists(String xPathExpression, InputSource control) throws IOException,
+			SAXException, XpathException {
+		Document inDocument = XMLUnit.buildControlDocument(control);
+		assertXpathNotExists(xPathExpression, inDocument);
+	}
+
+	/**
+	 * Assert that a specific XPath does NOT exist in some given XML
+	 * 
+	 * @param inXpathExpression
+	 * @param inXMLString
+	 * @see XpathEngine which provides the underlying evaluation mechanism
+	 */
+	public static void assertXpathNotExists(String xPathExpression, String inXMLString) throws IOException,
+			SAXException, XpathException {
+		Document inDocument = XMLUnit.buildControlDocument(inXMLString);
+		assertXpathNotExists(xPathExpression, inDocument);
+	}
+
+	/**
+	 * Assert that a specific XPath does NOT exist in some given XML
+	 * 
+	 * @param inXpathExpression
+	 * @param inDocument
+	 * @see XpathEngine which provides the underlying evaluation mechanism
+	 */
+	public static void assertXpathNotExists(String xPathExpression, Document inDocument) throws XpathException {
+		XpathEngine simpleXpathEngine = XMLUnit.newXpathEngine();
+		NodeList nodeList = simpleXpathEngine.getMatchingNodes(xPathExpression, inDocument);
+		int matches = nodeList.getLength();
+		assertEquals("Should be zero matches for Xpath " + xPathExpression, 0, matches);
+	}
+
+	/**
+	 * Assert that an InputSource containing XML contains valid XML: the
+	 * document must contain a DOCTYPE declaration to be validated
+	 * 
+	 * @param xml
+	 * @throws SAXException
+	 * @throws ConfigurationException
+	 *             if validation could not be turned on
+	 * @see Validator
+	 */
+	public static void assertXMLValid(InputSource xml) throws SAXException, ConfigurationException {
+		assertXMLValid(new Validator(xml));
+	}
+
+	/**
+	 * Assert that a String containing XML contains valid XML: the String must
+	 * contain a DOCTYPE declaration to be validated
+	 * 
+	 * @param xmlString
+	 * @throws SAXException
+	 * @throws ConfigurationException
+	 *             if validation could not be turned on
+	 * @see Validator
+	 */
+	public static void assertXMLValid(String xmlString) throws SAXException, ConfigurationException {
+		assertXMLValid(new Validator(xmlString));
+	}
+
+	/**
+	 * Assert that an InputSource containing XML contains valid XML: the
+	 * document must contain a DOCTYPE to be validated, but the validation will
+	 * use the systemId to obtain the DTD
+	 * 
+	 * @param xml
+	 * @param systemId
+	 * @throws SAXException
+	 * @throws ConfigurationException
+	 *             if validation could not be turned on
+	 * @see Validator
+	 */
+	public static void assertXMLValid(InputSource xml, String systemId) throws SAXException, ConfigurationException {
+		assertXMLValid(new Validator(xml, systemId));
+	}
+
+	/**
+	 * Assert that a String containing XML contains valid XML: the String must
+	 * contain a DOCTYPE to be validated, but the validation will use the
+	 * systemId to obtain the DTD
+	 * 
+	 * @param xmlString
+	 * @param systemId
+	 * @throws SAXException
+	 * @throws ConfigurationException
+	 *             if validation could not be turned on
+	 * @see Validator
+	 */
+	public static void assertXMLValid(String xmlString, String systemId) throws SAXException, ConfigurationException {
+		assertXMLValid(new Validator(xmlString, systemId));
+	}
+
+	/**
+	 * Assert that a piece of XML contains valid XML: the document will be given
+	 * a DOCTYPE to be validated with the name and systemId specified regardless
+	 * of whether it already contains a doctype declaration.
+	 * 
+	 * @param xml
+	 * @param systemId
+	 * @param doctype
+	 * @throws SAXException
+	 * @throws ConfigurationException
+	 *             if validation could not be turned on
+	 * @see Validator
+	 */
+	public static void assertXMLValid(InputSource xml, String systemId, String doctype) throws SAXException,
+			ConfigurationException {
+		assertXMLValid(new Validator(xml, systemId, doctype));
+	}
+
+	/**
+	 * Assert that a String containing XML contains valid XML: the String will
+	 * be given a DOCTYPE to be validated with the name and systemId specified
+	 * regardless of whether it already contains a doctype declaration.
+	 * 
+	 * @param xmlString
+	 * @param systemId
+	 * @param doctype
+	 * @throws SAXException
+	 * @throws ConfigurationException
+	 *             if validation could not be turned on
+	 * @see Validator
+	 */
+	public static void assertXMLValid(String xmlString, String systemId, String doctype) throws SAXException,
+			ConfigurationException {
+		assertXMLValid(new Validator(new StringReader(xmlString), systemId, doctype));
+	}
+
+	/**
+	 * Assert that a Validator instance returns <code>isValid() == true</code>
+	 * 
+	 * @param validator
+	 */
+	public static void assertXMLValid(Validator validator) {
+		assertEquals(validator.toString(), true, validator.isValid());
+	}
+
+	/**
+	 * Execute a <code>NodeTest<code> for a single node type
+	 * and assert that it passes
+	 * 
+	 * @param xml
+	 *            XML to be tested
+	 * @param tester
+	 *            The test strategy
+	 * @param nodeType
+	 *            The node type to be tested: constants defined in {@link Node
+	 *            org.w3c.dom.Node} e.g. <code>Node.ELEMENT_NODE</code>
+	 * @throws SAXException
+	 * @throws IOException
+	 * @see AbstractNodeTester
+	 * @see CountingNodeTester
+	 */
+	public static void assertNodeTestPasses(InputSource xml, NodeTester tester, short nodeType) throws SAXException,
+			IOException {
+		NodeTest test = new NodeTest(xml);
+		assertNodeTestPasses(test, tester, new short[] { nodeType }, true);
+	}
+
+	/**
+	 * Execute a <code>NodeTest<code> for a single node type
+	 * and assert that it passes
+	 * 
+	 * @param xmlString
+	 *            XML to be tested
+	 * @param tester
+	 *            The test strategy
+	 * @param nodeType
+	 *            The node type to be tested: constants defined in {@link Node
+	 *            org.w3c.dom.Node} e.g. <code>Node.ELEMENT_NODE</code>
+	 * @throws SAXException
+	 * @throws IOException
+	 * @see AbstractNodeTester
+	 * @see CountingNodeTester
+	 */
+	public static void assertNodeTestPasses(String xmlString, NodeTester tester, short nodeType) throws SAXException,
+			IOException {
+		NodeTest test = new NodeTest(xmlString);
+		assertNodeTestPasses(test, tester, new short[] { nodeType }, true);
+	}
+
+	/**
+	 * Execute a <code>NodeTest<code> for multiple node types and make an
+	 * assertion about it whether it is expected to pass
+	 * 
+	 * @param test
+	 *            a NodeTest instance containing the XML source to be tested
+	 * @param tester
+	 *            The test strategy
+	 * @param nodeTypes
+	 *            The node types to be tested: constants defined in {@link Node
+	 *            org.w3c.dom.Node} e.g. <code>Node.ELEMENT_NODE</code>
+	 * @param assertion
+	 *            true if the test is expected to pass, false otherwise
+	 * @see AbstractNodeTester
+	 * @see CountingNodeTester
+	 */
+	public static void assertNodeTestPasses(NodeTest test, NodeTester tester, short[] nodeTypes, boolean assertion) {
+		try {
+			test.performTest(tester, nodeTypes);
+			if (!assertion) {
+				fail("Expected node test to fail, but it passed!");
+			}
+		} catch (NodeTestException e) {
+			if (assertion) {
+				fail("Expected node test to pass, but it failed! " + e.getMessage());
+			}
+		}
+	}
+
+	private static Document asXpathResultDocument(final DocumentBuilder builder, final NodeList nodes) {
+		final Document d = builder.newDocument();
+		final Element root = d.createElement("xpathResult");
+		d.appendChild(root);
+		final int length = nodes.getLength();
+		for (int i = 0; i < length; i++) {
+			Node n = d.importNode(nodes.item(i), true);
+			if (n instanceof Attr) {
+				root.setAttributeNodeNS((Attr) n);
+			} else {
+				root.appendChild(n);
+			}
+		}
+		return d;
+	}
+}

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/AdtPlugin.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/AdtPlugin.java
@@ -298,6 +298,7 @@ public class AdtPlugin extends AbstractUIPlugin implements ILogger {
         // This is deferred in separate jobs to avoid blocking the bundle start.
         final boolean isSdkLocationValid = checkSdkLocationAndId();
         if (isSdkLocationValid) {
+        	System.out.println("Parsing sdk content.");
             // parse the SDK resources.
             // Wait 2 seconds before starting the job. This leaves some time to the
             // other bundles to initialize.
@@ -1146,7 +1147,8 @@ public class AdtPlugin extends AbstractUIPlugin implements ILogger {
              */
             @Override
             public boolean handleError(Solution solution, String message) {
-                displayMessage(solution, message, MessageDialog.ERROR);
+            	System.out.println("Message: " + message);
+                //displayMessage(solution, message, MessageDialog.ERROR);
                 return false;
             }
 
@@ -1158,7 +1160,8 @@ public class AdtPlugin extends AbstractUIPlugin implements ILogger {
              */
             @Override
             public boolean handleWarning(Solution solution, String message) {
-                displayMessage(solution, message, MessageDialog.WARNING);
+            	System.out.println("Message: " + message);
+                //displayMessage(solution, message, MessageDialog.WARNING);
                 return true;
             }
 

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/project/AndroidNature.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/project/AndroidNature.java
@@ -123,6 +123,7 @@ public class AndroidNature implements IProjectNature {
      */
     public static synchronized void setupProjectNatures(IProject project,
             IProgressMonitor monitor, boolean addAndroidNature) throws CoreException {
+    	System.out.println("Adding androind natures, setupProjectNatures");
         if (project == null || !project.isOpen()) return;
         if (monitor == null) monitor = new NullProgressMonitor();
 

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/wizards/newproject/NewProjectCreator.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/wizards/newproject/NewProjectCreator.java
@@ -718,6 +718,7 @@ public class NewProjectCreator  {
             boolean isAndroidProject)
                 throws CoreException, IOException, StreamException {
 
+    	
         // get the project target
         IAndroidTarget target = (IAndroidTarget) parameters.get(PARAM_SDK_TARGET);
         boolean legacy = isAndroidProject && target.getVersion().getApiLevel() < 4;
@@ -781,14 +782,17 @@ public class NewProjectCreator  {
             }
 
             // add the default proguard config
-            File libFolder = new File((String) parameters.get(PARAM_SDK_TOOLS_DIR),
-                    SdkConstants.FD_LIB);
-            addLocalFile(project,
-                    new File(libFolder, SdkConstants.FN_PROJECT_PROGUARD_FILE),
-                    // Write ProGuard config files with the extension .pro which
-                    // is what is used in the ProGuard documentation and samples
-                    SdkConstants.FN_PROJECT_PROGUARD_FILE,
-                    monitor);
+//            File libFolder = new File((String) parameters.get(PARAM_SDK_TOOLS_DIR),
+//                    SdkConstants.FD_LIB);
+            File libFolder = new File(Sdk.getCurrent().getSdkFileLocation(),
+                    SdkConstants.FD_TOOLS + File.separator + SdkConstants.FD_PROGUARD);
+
+//            addLocalFile(project,
+//                    new File(libFolder, SdkConstants.FN_PROJECT_PROGUARD_FILE),
+//                    // Write ProGuard config files with the extension .pro which
+//                    // is what is used in the ProGuard documentation and samples
+//                    SdkConstants.FN_PROJECT_PROGUARD_FILE,
+//                    monitor);
 
             // Set output location
             javaProject.setOutputLocation(project.getFolder(BIN_CLASSES_DIRECTORY).getFullPath(),
@@ -796,6 +800,7 @@ public class NewProjectCreator  {
         }
 
         File sampleDir = (File) parameters.get(PARAM_SAMPLE_LOCATION);
+
         if (sampleDir != null) {
             // Copy project
             copySampleCode(project, sampleDir, parameters, dictionary, monitor);
@@ -1364,7 +1369,7 @@ public class NewProjectCreator  {
         IFile dest = project.getFile(destName);
         if (dest.exists() == false) {
             FileInputStream stream = new FileInputStream(source);
-            dest.create(stream, false /* force */, new SubProgressMonitor(monitor, 10));
+            dest.create(stream, true /* force */, new SubProgressMonitor(monitor, 10));
         }
     }
 


### PR DESCRIPTION
This change request makes most of the Integration tests
so they can run either in the IDE or as part of the
maven build at the command line or on the CI server.
It does the following.

1. Makes sure the tests are independent of one another.
2. Tests now clean up after themselves. They are good boy scouts.
3. There is a DisplayMonitor job that watches for dialogs
   and dismisses any it finds.
4. Most tests are now using JUnit 4.
5. JUnit 4's TemporaryFolder rule is being used so that
   temporary files are removed after each test.
6. If the SDK fails to load for some reason, reload it
   so that valid targets are available for the tests.
7. Clean up our cache of tracked files that are to
   be deleted. Tests were adding files but never
   removing them.

In general there are fewer dialogs and fewer
test collisions.

Signed-off-by: David Carver <d_a_carver@yahoo.com>