### PR TITLE
Bring in robot provenance commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# Andmore Logo
-
-*The Android robot is reproduced or modified from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.*
-
 # Contributing
 
 [Andmore](https://www.eclipse.org/andmore) is a fork of the former MOTODEV Studio and Android Development Tools plugins for eclipse.
@@ -99,4 +95,8 @@ There is a project set that can be imported as an alternative to using Maven. Th
 is in android-core/plugins/org.eclipse.andmore/projectSet.psf.  The project set file is
 not guaranteed to be always updated, so if dependency issues arise, use the Maven import.
 
+## Andmore Logo
+
+*The Android robot is reproduced or modified from work created and shared by Google and 
+used according to terms described in the Creative Commons 3.0 Attribution License.*
 

--- a/andmore-core/plugins/common/about.properties
+++ b/andmore-core/plugins/common/about.properties
@@ -4,4 +4,7 @@ Version: {featureVersion}\n\
 \n\
 Build id: {1}\n\
 \n\
-Copyright (C) 2012 The Android Open Source Project
+Copyright (C) 2012 The Android Open Source Project\n\
+\n\
+The Android robot is reproduced or modified from work created and shared by Google and \
+used according to terms described in the Creative Commons 3.0 Attribution License.

--- a/android-core/plugins/org.eclipse.andmore.ddms/about.properties
+++ b/android-core/plugins/org.eclipse.andmore.ddms/about.properties
@@ -3,5 +3,7 @@ blurb=Dalvik Debug Monitor Service\n\
 Version\: {featureVersion}\n\
 \n\
 (c) Copyright 2007-2011 The Android Open Source Project.  All rights reserved.\n\
-Visit http://www.eclipse.org/andmore
-
+Visit http://www.eclipse.org/andmore\n\
+\n\
+The Android robot is reproduced or modified from work created and shared by Google and \
+used according to terms described in the Creative Commons 3.0 Attribution License.

--- a/android-core/plugins/org.eclipse.andmore.ndk/about.properties
+++ b/android-core/plugins/org.eclipse.andmore.ndk/about.properties
@@ -3,5 +3,7 @@ blurb=Android Development Toolkit\n\
 Version\: {featureVersion}\n\
 \n\
 (c) Copyright 2007-2011 The Android Open Source Project.  All rights reserved.\n\
-Visit http://www.eclipse.org/andmore
-
+Visit http://www.eclipse.org/andmore\n\
+\n\
+The Android robot is reproduced or modified from work created and shared by Google and \
+used according to terms described in the Creative Commons 3.0 Attribution License.

--- a/android-core/plugins/org.eclipse.andmore.package/about.properties
+++ b/android-core/plugins/org.eclipse.andmore.package/about.properties
@@ -3,4 +3,7 @@ blurb=Android Developer Tools\n\
 Build: {0}\n\
 \n\
 Copyright (c) The Android Open Source Project.\n\
-Visit http://www.eclipse.org/andmore
+Visit http://www.eclipse.org/andmore\n\
+\n\
+The Android robot is reproduced or modified from work created and shared by Google and \
+used according to terms described in the Creative Commons 3.0 Attribution License.

--- a/android-core/plugins/org.eclipse.andmore.traceview/about.properties
+++ b/android-core/plugins/org.eclipse.andmore.traceview/about.properties
@@ -3,5 +3,7 @@ blurb=Traceview\n\
 Version\: {featureVersion}\n\
 \n\
 (c) Copyright 2011 The Android Open Source Project.  All rights reserved.\n\
-Visit http://www.eclipse.org/andmore
-
+Visit http://www.eclipse.org/andmore\n\
+\n\
+The Android robot is reproduced or modified from work created and shared by Google and \
+used according to terms described in the Creative Commons 3.0 Attribution License.

--- a/android-core/plugins/org.eclipse.andmore/about.properties
+++ b/android-core/plugins/org.eclipse.andmore/about.properties
@@ -3,5 +3,7 @@ blurb=Android Development Toolkit\n\
 Version\: {featureVersion}\n\
 \n\
 (c) Copyright 2007-2011 The Android Open Source Project.  All rights reserved.\n\
-Visit http://developer.android.com/sdk/eclipse-adt.html
-
+Visit http://www.eclipse.org/andmore\n\
+\n\
+The Android robot is reproduced or modified from work created and shared by Google and \
+used according to terms described in the Creative Commons 3.0 Attribution License.


### PR DESCRIPTION
Acknowledging the provenance of the green robot used in some images and the CC terms
under which it is used.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=461075
Signed-off-by: Eric Cloninger <ericc@pobox.com>