### PR TITLE
[nobug] Set a build profile to skip tests

### DIFF
--- a/android-core/plugins/org.eclipse.andmore.integration.tests/pom.xml
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/pom.xml
@@ -202,5 +202,20 @@
 				<os-jvm-flags>-Xms256m -Xmx512m -XX:MaxPermSize=256M -XstartOnFirstThread</os-jvm-flags>
 			</properties>
 		</profile>
+		<profile>
+			<id>skipTests</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-surefire-plugin</artifactId>
+						<version>${tycho-version}</version>
+						<configuration>
+							<skipTests>true</skipTests>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
A new profile "skipTests" can be enabled.  This will
skip the integration tests during a build.

Signed-off-by: David Carver <d_a_carver@yahoo.com>