### PR TITLE
[461459] Restrict version of ObjectWeb Dependency

### DIFF
--- a/android-core/plugins/org.eclipse.andmore/META-INF/MANIFEST.MF
+++ b/android-core/plugins/org.eclipse.andmore/META-INF/MANIFEST.MF
@@ -50,8 +50,7 @@ Require-Bundle: org.eclipse.andmore.base,
  org.eclipse.core.expressions,
  org.eclipse.compare,
  org.eclipse.jdt.debug,
- org.objectweb.asm;bundle-version="5.0.1",
- org.objectweb.asm.tree;bundle-version="5.0.1"
+ org.objectweb.asm;bundle-version="[4.0.0,5.0.0)"
 Bundle-ActivationPolicy: lazy
 Export-Package: com.android.manifmerger;x-friends:="org.eclipse.andmore.integration.tests",
  com.android.ninepatch;x-friends:="org.eclipse.andmore.integration.tests",

--- a/android-core/plugins/org.eclipse.andmore/andmore.target
+++ b/android-core/plugins/org.eclipse.andmore/andmore.target
@@ -50,6 +50,7 @@
 <unit id="org.apache.oro" version="2.0.8.v201005080400"/>
 <unit id="org.easymock" version="2.4.0.v20090202-0900"/>
 <unit id="org.custommonkey.xmlunit" version="1.3.0.v201111161502"/>
+<unit id="org.objectweb.asm" version="4.0.0.v201302062210"/>
 <unit id="org.mockito" version="1.9.5.v201311280930"/>
 <unit id="org.apache.httpcomponents.httpclient" version="4.1.3.v201209201135"/>
 <unit id="org.apache.httpcomponents.httpcore" version="4.1.4.v201203221030"/>


### PR DESCRIPTION
The AOSP lint check tool requires that we use ObjectWeb ASM 4.0.
Any other version will cause NoClassDefFound errors to occur and
the build to lock.   This change makes sure the target platform
has 4.0 available to it, and also makes sure the plugin that
requires this excludes versions below 4.0 and 5.0.  We can't
use higher versions due to breaking API changes.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=461459
Signed-off-by: David Carver <d_a_carver@yahoo.com>