### PR TITLE
[461334] Allow users to select and use Java 1.8.

### DIFF
--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/AndmoreAndroidConstants.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/AndmoreAndroidConstants.java
@@ -221,13 +221,15 @@ public class AndmoreAndroidConstants {
      * Preferred compiler level, i.e. "1.7".
      */
     public final static String COMPILER_COMPLIANCE_PREFERRED = JavaCore.VERSION_1_7;
+    
     /**
-     * List of valid compiler level, i.e. "1.5", "1.6", and "1.7"
+     * List of valid compiler level
      */
     public final static String[] COMPILER_COMPLIANCE = {
         JavaCore.VERSION_1_5,
         JavaCore.VERSION_1_6,
-        JavaCore.VERSION_1_7
+        JavaCore.VERSION_1_7,
+        JavaCore.VERSION_1_8
     };
 
     /** The base URL where to find the Android class & manifest documentation */

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/project/ProjectHelper.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/project/ProjectHelper.java
@@ -875,7 +875,7 @@ public final class ProjectHelper {
             }
         }
 
-        if (JavaCore.VERSION_1_7.equals(optionValue)) {
+        if (JavaCore.VERSION_1_7.equals(optionValue) || JavaCore.VERSION_1_8.equals(optionValue)) {
             // Requires API 19 and buildTools 19
             Sdk currentSdk = Sdk.getCurrent();
             if (currentSdk != null) {


### PR DESCRIPTION
The default is to use Java 1.7, but we allow Java 1.8 per user
request for some tools that can backport lambdas.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=461334
Signed-off-by: David Carver <d_a_carver@yahoo.com>