### PR TITLE
[461960] Several files were missing copyright headers

### DIFF
--- a/android-core/plugins/org.eclipse.andmore.gldebugger/src/org/eclipse/andmore/gltrace/DeviceViewAction.java
+++ b/android-core/plugins/org.eclipse.andmore.gldebugger/src/org/eclipse/andmore/gltrace/DeviceViewAction.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.eclipse.andmore.gltrace;
 
 import com.android.ddmlib.Client;

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/DefaultDialogProcessor.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/DefaultDialogProcessor.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2006-2010 eBay Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *******************************************************************************/
+
+// copied from Ebay Turmeric Plugin project and used for monitoring dialogs to
+// be dismissed.
 package org.eclipse.andmore.integration.tests;
 
 

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/DialogMonitor.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/DialogMonitor.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2006-2010 eBay Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *******************************************************************************/
+
+// copied from Ebay Turmeric Plugin project and used for monitoring dialogs to
+// be dismissed.
 package org.eclipse.andmore.integration.tests;
 
 

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/DialogMonitorJob.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/DialogMonitorJob.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2006-2010 eBay Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *******************************************************************************/
+
+// copied from Ebay Turmeric Plugin project and used for monitoring dialogs to
+// be dismissed.
 package org.eclipse.andmore.integration.tests;
 
 import org.eclipse.jface.dialogs.DialogPage;

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/IDialogProcessor.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/IDialogProcessor.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2006-2010 eBay Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *******************************************************************************/
+
+// copied from Ebay Turmeric Plugin project and used for monitoring dialogs to
+// be dismissed.
 package org.eclipse.andmore.integration.tests;
 
 public interface IDialogProcessor {

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/IntegrationTestSuite.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/IntegrationTestSuite.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2015 David Carver and others
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.eclipse.andmore.integration.tests;
 
 import org.eclipse.andmore.integration.tests.functests.sampleProjects.SampleProjectTest;

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/UnitTestHelper.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/UnitTestHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.eclipse.andmore.integration.tests;
 
 import java.lang.reflect.Method;

--- a/android-core/plugins/org.eclipse.andmore.ndk/discovery/test.c
+++ b/android-core/plugins/org.eclipse.andmore.ndk/discovery/test.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/android-core/plugins/org.eclipse.andmore.ndk/discovery/test.cpp
+++ b/android-core/plugins/org.eclipse.andmore.ndk/discovery/test.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/Messages.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/Messages.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.eclipse.andmore;
 

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/build/Messages.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/build/Messages.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.eclipse.andmore.internal.build;
 

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/editors/layout/gle2/ShowWithinMenu.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/editors/layout/gle2/ShowWithinMenu.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.eclipse.andmore.internal.editors.layout.gle2;
 

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/editors/layout/gle2/SubmenuAction.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/editors/layout/gle2/SubmenuAction.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.eclipse.andmore.internal.editors.layout.gle2;
 

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/editors/ui/ErrorImageComposite.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/editors/ui/ErrorImageComposite.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.eclipse.andmore.internal.editors.ui;
 
 import static org.eclipse.ui.ISharedImages.IMG_DEC_FIELD_ERROR;

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/preferences/Messages.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/preferences/Messages.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.eclipse.andmore.internal.preferences;
 

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/wizards/templates/TypedVariable.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/wizards/templates/TypedVariable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.eclipse.andmore.internal.wizards.templates;
 
 import java.util.Locale;


### PR DESCRIPTION
Several files were missing appropriate copyright headers.
Most of these were from the original ADT project and were
missing when they were forked.  For consistency I have added
the basic headers back in.

Any new files that are created are licensed under the EPL
by the person creating the file.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=461960
Signed-off-by: David Carver <d_a_carver@yahoo.com>