### PR TITLE
[462184] Remove call to SdkStatsService

### DIFF
--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/preferences/AndroidPreferencePage.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/preferences/AndroidPreferencePage.java
@@ -256,11 +256,5 @@ public class AndroidPreferencePage extends FieldEditorPreferencePage implements
     @Override
     public void setVisible(boolean visible) {
         super.setVisible(visible);
-
-        /* When the ADT preferences page is made visible, display the dialog to obtain
-         * permissions for the ping service. */
-        SdkStatsService stats = new SdkStatsService();
-        Shell parent = getShell();
-        stats.checkUserPermissionForPing(parent);
     }
 }


### PR DESCRIPTION
SdkStatsService can popup a dialog the first time it is called
if the Android SDK location has not been specified.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=462184
Signed-off-by: David Carver <d_a_carver@yahoo.com>