### PR TITLE
[460134] Include object web dependency in feature

### DIFF
--- a/android-core/features/org.eclipse.andmore/feature.xml
+++ b/android-core/features/org.eclipse.andmore/feature.xml
@@ -141,11 +141,33 @@ This Agreement is governed by the laws of the State of New York and the intellec
    </requires>
 
    <plugin
+        id="org.objectweb.asm"
+         download-size="0"
+         install-size="0"
+         version="4.0.0.v201302062210"
+         unpack="false"/>
+        
+   <plugin
          id="org.eclipse.andmore"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+         
+   <plugin
+         id="org.eclipse.andmore.base"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+         
+    <plugin
+         id="org.eclipse.andmore.ddms"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 
    <plugin
          id="overlay.org.eclipse.andmore.overlay"


### PR DESCRIPTION
Include the objectweb dependency in the feature so that
third parties do not need to add eclipse orbit to their
build.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=460134
Signed-off-by: David Carver <d_a_carver@yahoo.com>