### PR TITLE
[461460] Fix Android Import Category

### DIFF
--- a/android-core/plugins/org.eclipse.andmore/plugin.xml
+++ b/android-core/plugins/org.eclipse.andmore/plugin.xml
@@ -155,7 +155,7 @@
     <extension
         point="org.eclipse.ui.importWizards">
         <category
-            id="org.eclispe.andmore.wizards.category"
+            id="org.eclipse.andmore.wizards.category"
             name="Android" />
         <wizard
             canFinishEarly="false"


### PR DESCRIPTION
Due to a mis-named category name the Android category was lost.
This fixes the category name so it is spelled correctly.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=461460
Signed-off-by: David Carver <d_a_carver@yahoo.com>