### PR TITLE
[463598] Convert ADT Projects to work with Andmore

### DIFF
--- a/andmore-core/plugins/android/plugin.properties
+++ b/andmore-core/plugins/android/plugin.properties
@@ -27,11 +27,15 @@ android.wizard.widget.project.description = Create a new Android widget project
 
 popupmenu.clean.projects.command.name=Clean selected project(s)
 
+popupmenu.convert.adt.projects.command.name=Convert to Andmore Project
+
 preferencePageName = Andmore for Android
 ndkPreferencePageName = Android NDK
 
 wizardName=Install Application
 wizardDescription=Transfers an application package to a device and installs it
+
+command.name.convert.adt.projects = Convert to Andmore Project
 
 command.localization.name=Open Localization Files Editor
 command.localization.description=Open the string editor for localization

--- a/andmore-core/plugins/android/plugin.xml
+++ b/andmore-core/plugins/android/plugin.xml
@@ -132,6 +132,12 @@
                   id="org.eclipse.andmore.android.clean.projects"
                   name="%popupmenu.clean.projects.command.name">
             </command>
+            <command
+            	 defaultHandler="org.eclipse.andmore.android.command.ConvertADTProject"
+            	 description="%popupmenu.convert.adt.projects.command.name"
+            	 id="org.eclipse.andmore.android.convert.adt.projects"
+            	 name="%popupmenu.convert.adt.projects.command.name">
+            </command>
          </extension>
          <extension
                point="org.eclipse.ui.menus">
@@ -249,7 +255,26 @@
                      label="%command.name.obfuscate"
                      style="push">
                </command>
-            </menuContribution>            
+            </menuContribution>   
+            <menuContribution
+                  locationURI="popup:org.eclipse.ui.projectConfigure">
+                  <command
+                     commandId="org.eclipse.andmore.android.convert.adt.projects"
+                     label="%command.name.convert.adt.projects"
+                     style="push">
+                       <visibleWhen
+                             checkEnabled="false">  
+                             <iterate operator="and" ifEmpty="false">                           
+	                             <adapt type="org.eclipse.core.resources.IResource">
+						             <test
+						                   property="org.eclipse.core.resources.projectNature"
+						                   value="com.android.ide.eclipse.adt.AndroidNature">
+						             </test>
+						         </adapt>
+					         </iterate>
+                       </visibleWhen>>
+                  </command>
+            </menuContribution>         
          </extension>
         <extension
                point="org.eclipse.andmore.android.logger.collector.log">

--- a/andmore-core/plugins/android/src/org/eclipse/andmore/android/command/ConvertADTProject.java
+++ b/andmore-core/plugins/android/src/org/eclipse/andmore/android/command/ConvertADTProject.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2015 David Carver
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.andmore.android.command;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.eclipse.andmore.AndmoreAndroidConstants;
+import org.eclipse.andmore.internal.build.builders.PostCompilerBuilder;
+import org.eclipse.andmore.internal.build.builders.PreCompilerBuilder;
+import org.eclipse.andmore.internal.build.builders.ResourceManagerBuilder;
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IProjectNature;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IAccessRule;
+import org.eclipse.jdt.core.IClasspathAttribute;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jface.resource.ResourceManager;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+
+import com.android.sdklib.build.ApkBuilder;
+
+public class ConvertADTProject extends AbstractHandler {
+
+	private List<IProject> projectList = null;
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		// Retrieve the selection used in the command
+		IWorkbench workbench = PlatformUI.getWorkbench();
+		if ((workbench == null) || workbench.isClosing()) {
+			return null;
+		}
+
+		IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
+		if (window == null) {
+			return null;
+		}
+
+		ISelection selection = window.getSelectionService().getSelection();
+		if (selection instanceof IStructuredSelection) {
+			IStructuredSelection sselection = (IStructuredSelection) selection;
+			Iterator<?> it = sselection.iterator();
+
+			// Construct a list of valid projects to be cleaned
+			projectList = new ArrayList<IProject>(sselection.size());
+
+			while (it.hasNext()) {
+				Object resource = it.next();
+
+				// Check if the selected item is a project
+				if (resource instanceof IJavaProject) {
+					projectList.add(((IProject) resource));
+				} else if (resource instanceof IAdaptable) {
+					IAdaptable adaptable = (IAdaptable) resource;
+					projectList.add((IProject) adaptable.getAdapter(IProject.class));
+				}
+			}
+			convertProjectsToAndmore();
+		}
+
+		return null;
+	}
+
+	@SuppressWarnings("restriction")
+	protected void convertProjectsToAndmore() {
+		// Probably should do a job here but for now we'll do everything in the
+		// command.
+		for (IProject project : projectList) {
+			try {
+				IJavaProject androidProject = (IJavaProject) project;
+				if (!project.hasNature(AndmoreAndroidConstants.ADT_NATURE)) {
+					break;
+				}
+				
+				updateProjectDescription(androidProject);
+				updateClasspathEntries(androidProject);
+
+			} catch (CoreException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+	
+	@SuppressWarnings("restriction")
+	private void updateClasspathEntries(IJavaProject androidProject) throws JavaModelException {
+		ArrayList<IClasspathEntry> newclasspathEntries = new ArrayList<IClasspathEntry>();
+
+		IClasspathEntry[] classpathEntries = androidProject.getRawClasspath();
+		for (IClasspathEntry classpathEntry : classpathEntries) {
+			if (classpathEntry.getEntryKind() == IClasspathEntry.CPE_CONTAINER) {
+				String classpathId = classpathEntry.getPath().toString();
+				if (classpathId.equals(AndmoreAndroidConstants.ADT_CONTAINER_DEPENDENCIES)) {
+					newclasspathEntries
+							.add(createNewAndmoreContainer(AndmoreAndroidConstants.CONTAINER_DEPENDENCIES));
+				} else if (classpathId.equals(AndmoreAndroidConstants.ADT_CONTAINER_FRAMEWORK)) {
+					newclasspathEntries
+							.add(createNewAndmoreContainer(AndmoreAndroidConstants.CONTAINER_FRAMEWORK));
+				} else if (classpathId.equals(AndmoreAndroidConstants.ADT_CONTAINER_PRIVATE_LIBRARIES)) {
+					newclasspathEntries
+							.add(createNewAndmoreContainer(AndmoreAndroidConstants.CONTAINER_PRIVATE_LIBRARIES));
+				}
+
+			} else {
+				newclasspathEntries.add(classpathEntry);
+			}
+		}
+
+		IClasspathEntry[] andmoreClasspathEntries = new IClasspathEntry[newclasspathEntries.size()];
+		newclasspathEntries.toArray(andmoreClasspathEntries);
+		androidProject.setRawClasspath(andmoreClasspathEntries, true, new NullProgressMonitor());
+
+	}
+
+	@SuppressWarnings("restriction")
+	private void updateProjectDescription(IJavaProject androidProject) throws CoreException {
+		IProjectDescription description = androidProject.getProject().getDescription();
+		description.setNatureIds(new String[] { AndmoreAndroidConstants.NATURE_DEFAULT, JavaCore.NATURE_ID });
+		description.setBuildConfigs(new String[] { ResourceManagerBuilder.ID, PostCompilerBuilder.ID,
+				PreCompilerBuilder.ID, JavaCore.BUILDER_ID });
+		androidProject.getProject().setDescription(description, new NullProgressMonitor());
+	}
+
+	private IClasspathEntry createNewAndmoreContainer(String id) {
+		IClasspathEntry andmoreClasspathEntry = JavaCore.newContainerEntry(new Path(id));
+		return andmoreClasspathEntry;
+	}
+
+}

--- a/andmore-core/plugins/android/src/org/eclipse/andmore/android/command/ConvertADTProject.java
+++ b/andmore-core/plugins/android/src/org/eclipse/andmore/android/command/ConvertADTProject.java
@@ -29,26 +29,20 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
-import org.eclipse.core.resources.IProjectNature;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.jdt.core.IAccessRule;
-import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 
-import com.android.sdklib.build.ApkBuilder;
 
 public class ConvertADTProject extends AbstractHandler {
 
@@ -80,7 +74,8 @@ public class ConvertADTProject extends AbstractHandler {
 
 				// Check if the selected item is a project
 				if (resource instanceof IJavaProject) {
-					projectList.add(((IProject) resource));
+					IJavaProject javaProject = (IJavaProject) resource;
+					projectList.add(javaProject.getProject());
 				} else if (resource instanceof IAdaptable) {
 					IAdaptable adaptable = (IAdaptable) resource;
 					projectList.add((IProject) adaptable.getAdapter(IProject.class));
@@ -98,10 +93,10 @@ public class ConvertADTProject extends AbstractHandler {
 		// command.
 		for (IProject project : projectList) {
 			try {
-				IJavaProject androidProject = (IJavaProject) project;
 				if (!project.hasNature(AndmoreAndroidConstants.ADT_NATURE)) {
 					break;
 				}
+				IJavaProject androidProject = JavaCore.create(project);
 				
 				updateProjectDescription(androidProject);
 				updateClasspathEntries(androidProject);
@@ -129,6 +124,8 @@ public class ConvertADTProject extends AbstractHandler {
 				} else if (classpathId.equals(AndmoreAndroidConstants.ADT_CONTAINER_PRIVATE_LIBRARIES)) {
 					newclasspathEntries
 							.add(createNewAndmoreContainer(AndmoreAndroidConstants.CONTAINER_PRIVATE_LIBRARIES));
+				} else {
+					newclasspathEntries.add(classpathEntry);
 				}
 
 			} else {
@@ -148,6 +145,7 @@ public class ConvertADTProject extends AbstractHandler {
 		description.setNatureIds(new String[] { AndmoreAndroidConstants.NATURE_DEFAULT, JavaCore.NATURE_ID });
 		description.setBuildConfigs(new String[] { ResourceManagerBuilder.ID, PostCompilerBuilder.ID,
 				PreCompilerBuilder.ID, JavaCore.BUILDER_ID });
+		
 		androidProject.getProject().setDescription(description, new NullProgressMonitor());
 	}
 

--- a/andmore-core/plugins/android/src/org/eclipse/andmore/android/command/ConvertADTProject.java
+++ b/andmore-core/plugins/android/src/org/eclipse/andmore/android/command/ConvertADTProject.java
@@ -27,6 +27,7 @@ import org.eclipse.andmore.internal.build.builders.ResourceManagerBuilder;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
@@ -143,6 +144,22 @@ public class ConvertADTProject extends AbstractHandler {
 	private void updateProjectDescription(IJavaProject androidProject) throws CoreException {
 		IProjectDescription description = androidProject.getProject().getDescription();
 		description.setNatureIds(new String[] { AndmoreAndroidConstants.NATURE_DEFAULT, JavaCore.NATURE_ID });
+		
+		ICommand commands[] = description.getBuildSpec();
+		ArrayList<ICommand> acutalCommands = new ArrayList<ICommand>();
+		for (ICommand command : commands) {
+			if (!command.getBuilderName().equals("com.android.ide.eclipse.adt.PreCompilerBuilder") &&
+				!command.getBuilderName().equals("com.android.ide.eclipse.adt.ResourceManagerBuilder") &&
+				!command.getBuilderName().equals("com.android.ide.eclipse.adt.ApkBuilder")) {
+				acutalCommands.add(command);
+			}
+		}
+		
+		ICommand keepCommands[] = new ICommand[acutalCommands.size()];
+		acutalCommands.toArray(keepCommands);
+		
+		description.setBuildSpec(keepCommands);
+		
 		description.setBuildConfigs(new String[] { ResourceManagerBuilder.ID, PostCompilerBuilder.ID,
 				PreCompilerBuilder.ID, JavaCore.BUILDER_ID });
 		

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/AndmoreAndroidConstants.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/AndmoreAndroidConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007 The Android Open Source Project
+ * Copyright (C) 2007-2015 The Android Open Source Project and others
  *
  * Licensed under the Eclipse Public License, Version 1.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * 
+ * David Carver - bug 463598 - Re-add ADT Specific nature ids and container ids.
+ * 
  */
 
 package org.eclipse.andmore;
@@ -59,14 +62,25 @@ public class AndmoreAndroidConstants {
 
     /** Nature of default Android projects */
     public final static String NATURE_DEFAULT = "org.eclipse.andmore.AndroidNature"; //$NON-NLS-1$
+    
+    public final static String ADT_NATURE = "com.android.ide.eclipse.adt.AndroidNature"; //$NON-NLS-1$
 
     /** The container id for the android framework jar file */
     public final static String CONTAINER_FRAMEWORK =
         "org.eclipse.andmore.ANDROID_FRAMEWORK"; //$NON-NLS-1$
+    
+    /** The container id for the android framework jar file */
+    public final static String ADT_CONTAINER_FRAMEWORK =
+        "com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"; //$NON-NLS-1$
 
     /** The container id for the libraries */
     public final static String CONTAINER_PRIVATE_LIBRARIES = "org.eclipse.andmore.LIBRARIES"; //$NON-NLS-1$
+    
+    public final static String ADT_CONTAINER_PRIVATE_LIBRARIES = "com.android.ide.eclipse.adt.LIBRARIES"; //$NON-NLS-1$
+    
     public final static String CONTAINER_DEPENDENCIES = "org.eclipse.andmore.DEPENDENCIES";
+    
+    public final static String ADT_CONTAINER_DEPENDENCIES = "com.android.ide.eclipse.adt.DEPENDENCIES";
 
 
     /** Separator for workspace path, i.e. "/". */


### PR DESCRIPTION
A simple command that takes a list of projects selected from the
UI and converts them to use the Andmore nature and Builder ids.
This is a work in progress.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=463598
Signed-off-by: David Carver <d_a_carver@yahoo.com>