### PR TITLE
[463916] Add platform independent NEWLINE constant

### DIFF
--- a/android-core/plugins/org.eclipse.andmore.ddms/src/org/eclipse/andmore/ddms/DdmsPlugin.java
+++ b/android-core/plugins/org.eclipse.andmore.ddms/src/org/eclipse/andmore/ddms/DdmsPlugin.java
@@ -73,6 +73,8 @@ public final class DdmsPlugin extends AbstractUIPlugin implements IDeviceChangeL
 
 	// The plug-in ID
 	public static final String PLUGIN_ID = "org.eclipse.andmore.ddms"; //$NON-NLS-1$
+	
+	public static final String NEWLINE = System.getProperty("line.separator");
 
 	/** The singleton instance */
 	private static DdmsPlugin sPlugin;

--- a/android-core/plugins/org.eclipse.andmore.ddms/src/org/eclipse/andmore/ddms/LogCatMonitorDialog.java
+++ b/android-core/plugins/org.eclipse.andmore.ddms/src/org/eclipse/andmore/ddms/LogCatMonitorDialog.java
@@ -34,7 +34,7 @@ import org.eclipse.swt.widgets.Shell;
 
 public class LogCatMonitorDialog extends TitleAreaDialog {
 	private static final String TITLE = "Auto Monitor Logcat";
-	private static final String DEFAULT_MESSAGE = "Would you like ADT to automatically monitor logcat \n"
+	private static final String DEFAULT_MESSAGE = "Would you like ADT to automatically monitor logcat " + DdmsPlugin.NEWLINE
 			+ "output for messages from applications in the workspace?";
 
 	private boolean mShouldMonitor = true;
@@ -69,7 +69,7 @@ public class LogCatMonitorDialog extends TitleAreaDialog {
 		disableButton.setText("No, do not monitor logcat output.");
 
 		final Button enableButton = new Button(c, SWT.RADIO);
-		enableButton.setText("Yes, monitor logcat and display logcat view if there are\n"
+		enableButton.setText("Yes, monitor logcat and display logcat view if there are" + DdmsPlugin.NEWLINE 
 				+ "messages with priority higher than:");
 		enableButton.setSelection(true);
 

--- a/android-core/plugins/org.eclipse.andmore/.settings/org.moreunit.prefs
+++ b/android-core/plugins/org.eclipse.andmore/.settings/org.moreunit.prefs
@@ -1,4 +1,4 @@
 eclipse.preferences.version=1
-org.moreunit.prefixes=
+org.moreunit.preferences.version=2
 org.moreunit.unitsourcefolder=plugin-adt\:src\:plugin-tests\:unittests\#plugin-adt\:src\:plugin-tests\:src
 org.moreunit.useprojectsettings=true

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/AndmoreAndroidConstants.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/AndmoreAndroidConstants.java
@@ -256,4 +256,6 @@ public class AndmoreAndroidConstants {
 
     public static final String DEX_OPTIONS_FORCEJUMBO = "dex.force.jumbo"; //$NON-NLS-1$
     public static final String DEX_OPTIONS_DISABLE_MERGER = "dex.disable.merger"; //$NON-NLS-1$
+    
+    public static final String NEWLINE = System.getProperty("line.separator");
 }


### PR DESCRIPTION
There are cases where \n is not working as expected, use the system
defined NEWLINE provided by the java runtime.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=463916
Signed-off-by: David Carver <d_a_carver@yahoo.com>