### PR TITLE
[471901] Android Common XML Editor should not be the default

### DIFF
--- a/android-core/plugins/org.eclipse.andmore/plugin.xml
+++ b/android-core/plugins/org.eclipse.andmore/plugin.xml
@@ -660,7 +660,7 @@
         <editor
               class="org.eclipse.andmore.internal.editors.common.CommonXmlEditor"
               contributorClass="org.eclipse.andmore.internal.editors.common.CommonActionContributor"
-              default="true"
+              default="false"
               extensions="xml"
               icon="icons/android_file.png"
               id="org.eclipse.andmore.editors.CommonXmlEditor"


### PR DESCRIPTION
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=471901
Signed-off-by: Kaloyan Raev <kaloyan.r@zend.com>