### PR TITLE
[468473] NPE when expanding application node in db explorer

### DIFF
--- a/andmore-core/plugins/db.devices/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/db.devices/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.console,
  org.eclipse.datatools.sqltools.result,
  org.eclipse.sequoyah.device.framework,
- org.eclipse.core.resources
+ org.eclipse.core.resources,
+ org.eclipse.andmore;bundle-version="0.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/andmore-core/plugins/db.devices/src/org/eclipse/andmore/android/db/devices/model/ApplicationNode.java
+++ b/andmore-core/plugins/db.devices/src/org/eclipse/andmore/android/db/devices/model/ApplicationNode.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.andmore.AndmoreAndroidPlugin;
+import org.eclipse.andmore.android.AndroidPlugin;
 import org.eclipse.andmore.android.DDMSUtils;
 import org.eclipse.andmore.android.db.core.CanRefreshStatus;
 import org.eclipse.andmore.android.db.core.exception.AndmoreDbException;
@@ -65,7 +67,7 @@ public class ApplicationNode extends AbstractTreeNode implements IDbCreatorNode 
 		this.appName = appName;
 		setId(appName);
 		setName(appName);
-		ImageDescriptor icon = AbstractUIPlugin.imageDescriptorFromPlugin("org.eclipe.andmore", //$NON-NLS-1$
+		ImageDescriptor icon = AbstractUIPlugin.imageDescriptorFromPlugin(AndmoreAndroidPlugin.PLUGIN_ID, //$NON-NLS-1$
 				"icons/android.png"); //$NON-NLS-1$
 		setIcon(icon);
 	}


### PR DESCRIPTION
An NPE would be thrown when trying to show the icon for an application
in the database explorer for the Android Database perspective.
The dependency was missing and the wrong value was hard coded.  Plugin
now uses the correct Constant value instead of a magic value.  So if the
constant value changes this will be picked up automatically.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=468473
Signed-off-by: David Carver <d_a_carver@yahoo.com>