### PR TITLE
[476446] MultiDex support for Android APK

### DIFF
--- a/andmore-core/plugins/android/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/android/META-INF/MANIFEST.MF
@@ -33,6 +33,7 @@ Export-Package:
  org.eclipse.andmore.android.devices,
  org.eclipse.andmore.android.i18n,
  org.eclipse.andmore.android.model,
+ org.eclipse.andmore.android.multidex,
  org.eclipse.andmore.android.nativeos,
  org.eclipse.andmore.android.sdkmanager,
  org.eclipse.andmore.android.utilities,

--- a/andmore-core/plugins/android/files/main-dex-list.txt
+++ b/andmore-core/plugins/android/files/main-dex-list.txt
@@ -1,0 +1,10 @@
+android/support/multidex/BuildConfig.class
+android/support/multidex/MultiDex$V14.class
+android/support/multidex/MultiDex$V19.class
+android/support/multidex/MultiDex$V4.class
+android/support/multidex/MultiDex.class
+android/support/multidex/MultiDexApplication.class
+android/support/multidex/MultiDexExtractor$1.class
+android/support/multidex/MultiDexExtractor.class
+android/support/multidex/ZipUtil$CentralDirectory.class
+android/support/multidex/ZipUtil.class

--- a/andmore-core/plugins/android/src/org/eclipse/andmore/android/i18n/AndroidNLS.java
+++ b/andmore-core/plugins/android/src/org/eclipse/andmore/android/i18n/AndroidNLS.java
@@ -384,6 +384,12 @@ public class AndroidNLS extends NLS {
 	public static String UI_ProjectPropertyPage_Obfuscate;
 
 	public static String UI_ProjectPropertyPage_ObfuscateGroup;
+	
+	public static String UI_ProjectCreation_Multidex;
+
+	public static String UI_ProjectPropertyPage_MultiDex;
+
+	public static String UI_ProjectPropertyPage_MultiDexGroup;
 
 	public static String UI_Logger_ApplicationValidatorFolder;
 

--- a/andmore-core/plugins/android/src/org/eclipse/andmore/android/i18n/androidNLS.properties
+++ b/andmore-core/plugins/android/src/org/eclipse/andmore/android/i18n/androidNLS.properties
@@ -206,6 +206,11 @@ UI_CleanProjectsJob_Description=Cleaning projects...
 UI_ProjectCreation_Obfuscate=Obfuscate Java classes
 UI_ProjectPropertyPage_Obfuscate=Obfuscate Java classes
 UI_ProjectPropertyPage_ObfuscateGroup=Obfuscation
+
+UI_ProjectCreation_MultiDex=Enable MultiDex support
+UI_ProjectPropertyPage_MultiDex=Enable MultiDex support
+UI_ProjectPropertyPage_MultiDexGroup=MultiDex
+
 UI_Logger_ApplicationValidatorFolder=App Validator
 
 EXC_AndroidProject_AnErrorHasOccurredWhenCreatingTheProject=An error has occurred while creating the project.

--- a/andmore-core/plugins/android/src/org/eclipse/andmore/android/multidex/MultiDexManager.java
+++ b/andmore-core/plugins/android/src/org/eclipse/andmore/android/multidex/MultiDexManager.java
@@ -22,17 +22,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Properties;
 import java.util.Scanner;
 
 import org.eclipse.andmore.android.AndroidPlugin;
 import org.eclipse.andmore.android.common.log.AndmoreLogger;
 import org.eclipse.andmore.android.common.log.UsageDataConstants;
-import org.eclipse.andmore.android.common.utilities.AndroidUtils;
-import org.eclipse.andmore.internal.sdk.ProjectState;
-import org.eclipse.andmore.internal.sdk.Sdk;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;

--- a/andmore-core/plugins/android/src/org/eclipse/andmore/android/multidex/MultiDexManager.java
+++ b/andmore-core/plugins/android/src/org/eclipse/andmore/android/multidex/MultiDexManager.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.andmore.android.multidex;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Properties;
+import java.util.Scanner;
+
+import org.eclipse.andmore.android.AndroidPlugin;
+import org.eclipse.andmore.android.common.log.AndmoreLogger;
+import org.eclipse.andmore.android.common.log.UsageDataConstants;
+import org.eclipse.andmore.android.common.utilities.AndroidUtils;
+import org.eclipse.andmore.internal.sdk.ProjectState;
+import org.eclipse.andmore.internal.sdk.Sdk;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubMonitor;
+import org.osgi.framework.Bundle;
+
+import com.android.sdklib.internal.project.ProjectProperties;
+import com.android.sdklib.internal.project.ProjectProperties.PropertyType;
+
+/**
+ * Manager to enable MultiDex for projects with too many classes. 
+ * 
+ * Add two properties to the project.properties:
+ * multidex.enabled=true
+ * multidex.main-dex-list=main-dex-list.txt
+ * 
+ * Also copies the main-dex-list.txt file
+ */
+public class MultiDexManager {
+
+	private static final String MULTIDEX_MAIN_DEX_LIST_PATH = "/files/main-dex-list.txt";
+	private static final String MULTIDEX_MAIN_DEX_LIST_FILENAME = "main-dex-list.txt";
+
+	private static final String MULTIDEX_ENABLED_PROPERTY = "multidex.enabled";
+	private static final String MULTIDEX_ENABLED_STATEMENT = MULTIDEX_ENABLED_PROPERTY + "=true";
+	
+	private static final String MULTIDEX_MAIN_DEX_LIST_PROPERTY = "multidex.main-dex-list";
+	private static final String MULTIDEX_MAIN_DEX_LIST_STATEMENT = MULTIDEX_MAIN_DEX_LIST_PROPERTY + "=main-dex-list.txt";
+
+	private static final String DEFAULT_PROPERTIES_FILENAME = "default.properties";
+	private static final String PROJECT_PROPERTIES_FILENAME = "project.properties";
+
+	private static final String NL = System.getProperty("line.separator");
+	
+	/**
+	 * Prepares the project with the MultiDex settings
+	 * 
+	 * @param project
+	 * @param monitor
+	 * @return
+	 */
+	public static IStatus enableMultiDex(IProject project, IProgressMonitor monitor) {
+		IStatus status = Status.OK_STATUS;
+		
+		File projectPropertiesFile = project.getFile(PROJECT_PROPERTIES_FILENAME).getLocation().toFile();
+		File defaultPropertiesFile = project.getFile(DEFAULT_PROPERTIES_FILENAME).getLocation().toFile();
+		if (projectPropertiesFile.canWrite()) {
+			defaultPropertiesFile = projectPropertiesFile;
+		}
+		
+		try {
+			addMultiDexEnabledStatement(defaultPropertiesFile);
+			
+			File mainDexListFile = getMainDexListFile(project);
+			if(mainDexListFile == null) {
+				addMainDexListStatement(defaultPropertiesFile);
+				if (!fileExists(mainDexListFile)) {
+					copyMainDexListFile(project, monitor);
+				}
+			}
+			try {
+				project.refreshLocal(IResource.DEPTH_ONE, null);
+			} catch (CoreException e) {
+				// Do nothing, user just have to press F5
+			}
+		} catch (Exception e) {
+			AndmoreLogger.error(MultiDexManager.class, "Error while setting main-class-list for use with multidex", e);
+			status = new Status(IStatus.ERROR, AndroidPlugin.PLUGIN_ID, "Could not enable multidex", e);
+		}
+
+		AndmoreLogger.collectUsageData(UsageDataConstants.WHAT_OBFUSCATE, UsageDataConstants.KIND_OBFUSCATE,
+				UsageDataConstants.DESCRIPTION_DEFAULT, AndroidPlugin.PLUGIN_ID, AndroidPlugin.getDefault().getBundle()
+						.getVersion().toString());
+
+		return status;
+	}
+
+	/**
+	 * Removes MultiDex settings 
+	 * 
+	 * @param project
+	 * @return
+	 */
+	public static IStatus disableMultiDex(IProject project) {
+		IStatus status = Status.OK_STATUS;
+		
+		File projectPropertiesFile = project.getFile(PROJECT_PROPERTIES_FILENAME).getLocation().toFile();
+		File defaultPropertiesFile = project.getFile(DEFAULT_PROPERTIES_FILENAME).getLocation().toFile();
+		if (projectPropertiesFile.canWrite()) {
+			defaultPropertiesFile = projectPropertiesFile;
+		}
+
+		try {
+			removeMultiStatements(defaultPropertiesFile);
+			
+			try {
+				project.refreshLocal(IResource.DEPTH_ONE, null);
+			} catch (CoreException e) {
+				// Do nothing, user just have to press F5
+			}
+		} catch (Exception e) {
+			AndmoreLogger.error(MultiDexManager.class, "Error while removing MultiDex settings", e);
+			status = new Status(IStatus.ERROR, AndroidPlugin.PLUGIN_ID, "Could not remove MultiDex settings", e);
+		}
+
+		AndmoreLogger.collectUsageData(UsageDataConstants.WHAT_OBFUSCATE, UsageDataConstants.KIND_DESOBFUSCATE,
+				UsageDataConstants.DESCRIPTION_DEFAULT, AndroidPlugin.PLUGIN_ID, AndroidPlugin.getDefault().getBundle()
+						.getVersion().toString());
+
+		return status;
+	}
+
+	/*
+	 * @param propertiesFile file to write
+	 * 
+	 * @param newContent content to write (replaces entire file)
+	 * 
+	 * @throws IOException
+	 */
+	private static void write(File propertiesFile, String newContent) throws IOException {
+		Writer out = new OutputStreamWriter(new FileOutputStream(propertiesFile));
+		try {
+			out.write(newContent);
+		} finally {
+			if (out != null) {
+				out.close();
+			}
+		}
+	}
+
+	/*
+	 * @param ignoreMultiDexStatement true it does not return the lines with
+	 * multidex.config and multidex.enabled
+	 * 
+	 * @return
+	 * 
+	 * @throws IOException
+	 */
+	private static String read(File propertiesFile, boolean ignoreMultiDexStatement) throws IOException {
+		StringBuilder text = new StringBuilder();
+		Scanner scanner = null;
+		FileInputStream stream = null;
+		try {
+			stream = new FileInputStream(propertiesFile);
+			scanner = new Scanner(stream);
+			while (scanner.hasNextLine()) {
+				String line = scanner.nextLine();
+				if (!ignoreMultiDexStatement || (!line.contains(MULTIDEX_MAIN_DEX_LIST_PROPERTY) && !line.contains(MULTIDEX_ENABLED_PROPERTY))) {
+					text.append(line + NL);
+				}
+			}
+		} finally {
+			try {
+				if (scanner != null) {
+					scanner.close();
+				}
+				if (stream != null) {
+					stream.close();
+				}
+			} catch (IOException e) {
+				AndmoreLogger.info("Could not close stream while reading project.properties file. " + e.getMessage());
+			}
+		}
+		return text.toString();
+	}
+
+	private static boolean fileExists(File multiDexFile) {
+		return (multiDexFile != null) && multiDexFile.exists();
+	}
+
+	/**
+	 * Add the following line to file multidex.enabled=true if it does
+	 * not exist yet
+	 * 
+	 * @param project
+	 * @throws IOException
+	 */
+	private static void addMultiDexEnabledStatement(File propertiesFile) throws IOException {
+		String currentContent = null;
+		currentContent = read(propertiesFile, false);
+		if (!currentContent.toString().contains(MULTIDEX_ENABLED_STATEMENT)) {
+			String newContent = currentContent.endsWith(NL) ? currentContent + MULTIDEX_ENABLED_STATEMENT
+					: currentContent + NL + MULTIDEX_ENABLED_STATEMENT;
+			write(propertiesFile, newContent);
+		}
+	}
+	
+	/**
+	 * Add the following line to file multidex.main-dex-list=main-dex-list.txt if it does
+	 * not exist yet
+	 * 
+	 * @param project
+	 * @throws IOException
+	 */
+	private static void addMainDexListStatement(File propertiesFile) throws IOException {
+		String currentContent = null;
+		currentContent = read(propertiesFile, false);
+		if (!currentContent.toString().contains(MULTIDEX_MAIN_DEX_LIST_STATEMENT)) {
+			String newContent = currentContent.endsWith(NL) ? currentContent + MULTIDEX_MAIN_DEX_LIST_STATEMENT
+					: currentContent + NL + MULTIDEX_MAIN_DEX_LIST_STATEMENT;
+			write(propertiesFile, newContent);
+		}
+	}
+
+	/**
+	 * Remove any of the following lines from project.properties (multidex.enabled=true, multidex.config=main-dex-list.txt)
+	 * exists
+	 * 
+	 * @param project
+	 * @throws IOException
+	 */
+	private static void removeMultiStatements(File propertiesFile) throws IOException {
+		String contentWithoutMultiDexStatement = null;
+		contentWithoutMultiDexStatement = read(propertiesFile, true);
+		write(propertiesFile, contentWithoutMultiDexStatement);
+	}
+
+	private static void copyMainDexListFile(IProject project, IProgressMonitor monitor) throws IOException, CoreException {
+		SubMonitor subMonitor = SubMonitor.convert(monitor);
+
+		URL mainDexListURL = getMultiDexKeepFileURL();
+		if (mainDexListURL != null) {
+			InputStream is = null;
+			try {
+				is = mainDexListURL.openStream();
+				IFile destFile = project.getFile(MULTIDEX_MAIN_DEX_LIST_FILENAME);
+				destFile.create(is, IResource.NONE, subMonitor);
+			} finally {
+				if (is != null) {
+					is.close();
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get the most suitable main-class-list file, either from SDK or our plug-in
+	 * 
+	 * @return the URL of the best main-class-list file found
+	 */
+	private static URL getMultiDexKeepFileURL() {
+		Bundle bundle = AndroidPlugin.getDefault().getBundle();
+		URL fileURL = bundle.getEntry(MULTIDEX_MAIN_DEX_LIST_PATH);
+
+		return fileURL;
+	}
+	
+	public static boolean isMultiDexEnabled(IProject project) {
+		// get the project info
+		ProjectProperties projectProperties = getProjectProperties(project);
+
+        // this can happen if the project has no project.properties.
+        if (projectProperties == null) {
+            return false;
+        }
+        
+        String multiDexEnabled = projectProperties.getProperty(MULTIDEX_ENABLED_PROPERTY);
+        if(multiDexEnabled == null) {
+        	return false;
+        }
+        
+        return Boolean.parseBoolean(multiDexEnabled);
+	}
+	
+	public static File getMainDexListFile(IProject project) {
+		// get the project info
+		ProjectProperties projectProperties = getProjectProperties(project);
+
+        // this can happen if the project has no project.properties.
+        if (projectProperties == null) {
+            return null;
+        }
+        
+        String mainDexListLocation = projectProperties.getProperty(MULTIDEX_MAIN_DEX_LIST_PROPERTY);
+        if(mainDexListLocation == null) {
+        	return null;
+        }
+        
+        return project.getFile(mainDexListLocation).getLocation().toFile();
+	}
+	
+	private static ProjectProperties getProjectProperties(IProject project) {
+		String projectLocation = project.getLocation().toOSString();
+		
+		// legacy support: look for default.properties
+        ProjectProperties properties = ProjectProperties.load(projectLocation,
+                PropertyType.LEGACY_DEFAULT);
+        if(properties == null) {
+        	properties = ProjectProperties.load(projectLocation, PropertyType.PROJECT);
+        }
+        
+        return properties;
+	}
+}

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/META-INF/MANIFEST.MF
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: org.junit,
  org.eclipse.andmore.base,
  org.eclipse.andmore,
  org.easymock,
- org.custommonkey.xmlunit
+ org.custommonkey.xmlunit,
+ org.eclipse.andmore.android
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ClassPath: .,
  libs/kxml2-2.3.0.jar,

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/IntegrationTestSuite.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/integration/tests/IntegrationTestSuite.java
@@ -19,6 +19,7 @@ package org.eclipse.andmore.integration.tests;
 import org.eclipse.andmore.integration.tests.functests.sampleProjects.SampleProjectTest;
 import org.eclipse.andmore.internal.build.AaptParserTest;
 import org.eclipse.andmore.internal.build.AaptQuickFixTest;
+import org.eclipse.andmore.internal.build.DexWrapperTest;
 import org.eclipse.andmore.internal.editors.AndroidContentAssistTest;
 import org.eclipse.andmore.internal.editors.AndroidXmlAutoEditStrategyTest;
 import org.eclipse.andmore.internal.editors.AndroidXmlCharacterMatcherTest;
@@ -31,6 +32,7 @@ import org.eclipse.andmore.internal.lint.ProjectLintConfigurationTest;
 import org.eclipse.andmore.internal.refactorings.core.AndroidPackageRenameParticipantTest;
 import org.eclipse.andmore.internal.refactorings.core.RenameResourceParticipantTest;
 import org.eclipse.andmore.internal.refactorings.renamepackage.ApplicationPackageNameRefactoringTest;
+import org.eclipse.andmore.internal.settings.MultiDexTest;
 import org.eclipse.andmore.internal.wizards.exportgradle.ExportGradleTest;
 import org.eclipse.andmore.internal.wizards.templates.TemplateHandlerTest;
 import org.junit.runner.RunWith;
@@ -40,6 +42,8 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({SampleProjectTest.class,
 	AaptParserTest.class,
 	AaptQuickFixTest.class,
+	DexWrapperTest.class,
+	MultiDexTest.class,
 	EclipseXmlPrettyPrinterTest.class,
 	AndroidContentAssistTest.class,
 	AndroidXmlAutoEditStrategyTest.class,

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/build/DexWrapperTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/build/DexWrapperTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -28,6 +29,7 @@ import org.eclipse.andmore.internal.build.DexWrapper;
 import org.eclipse.andmore.internal.editors.layout.refactoring.AdtProjectTest;
 import org.eclipse.andmore.internal.sdk.ProjectState;
 import org.eclipse.andmore.internal.sdk.Sdk;
+import org.eclipse.core.resources.IProject;
 import org.junit.Test;
 
 import com.android.sdklib.BuildToolInfo;
@@ -44,7 +46,7 @@ public class DexWrapperTest extends AdtProjectTest {
 	}
 	
 	@Test
-	public void testMainClassFieldsAvailable() {
+	public void testMainClassFieldsAvailable() {		
 		Class<?> mainDexClass = loadMainDexClass();
 		
 		try {
@@ -109,7 +111,18 @@ public class DexWrapperTest extends AdtProjectTest {
 		ProjectState projectState = Sdk.getProjectState(getProject());
 		assertNotNull(projectState);
 		
-		String dxLocation = projectState.getBuildToolInfo().getPath(BuildToolInfo.PathId.DX_JAR);
+		BuildToolInfo buildToolInfo = projectState.getBuildToolInfo();
+        if (buildToolInfo == null) {
+            buildToolInfo = getSdk().getLatestBuildTool();
+        }
+        assertNotNull(buildToolInfo);
+        
+        if(buildToolInfo.getRevision().getMajor() < 21) {
+        	fail("DexWrapper only works with build tools version 21 and higher. "
+        			+ "Currently trying to use " + buildToolInfo.getRevision().getMajor());
+        }
+        
+		String dxLocation = buildToolInfo.getPath(BuildToolInfo.PathId.DX_JAR);
 		
 		File f = new File(dxLocation);	
 		URL url = null;

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/build/DexWrapperTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/build/DexWrapperTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.andmore.internal.build;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.eclipse.andmore.internal.build.DexWrapper;
+import org.eclipse.andmore.internal.editors.layout.refactoring.AdtProjectTest;
+import org.eclipse.andmore.internal.sdk.ProjectState;
+import org.eclipse.andmore.internal.sdk.Sdk;
+import org.junit.Test;
+
+import com.android.sdklib.BuildToolInfo;
+
+/**
+ * Test case to see if the DexWrapper can still be executed.
+ */
+
+public class DexWrapperTest extends AdtProjectTest {
+	
+	@Test
+	public void testMainDexClassExists() {
+		loadMainDexClass();
+	}
+	
+	@Test
+	public void testMainClassFieldsAvailable() {
+		Class<?> mainDexClass = loadMainDexClass();
+		
+		try {
+			mainDexClass.getDeclaredField(DexWrapper.DEX_MAIN_FIELD_OUTPUT_FUTURES);
+			mainDexClass.getDeclaredField(DexWrapper.DEX_MAIN_FIELD_OUTPUT_ARRAYS);
+			mainDexClass.getDeclaredField(DexWrapper.DEX_MAIN_FIELD_CLASSES_IN_MAIN_DEX);
+			mainDexClass.getDeclaredField(DexWrapper.DEX_MAIN_FIELD_OUTPUT_RESOURCES);
+		} catch (SecurityException e) {
+			fail(e.getLocalizedMessage());
+	    } catch (NoSuchFieldException e) {
+	    	fail(e.getLocalizedMessage());
+	    }
+	}
+	
+	@Test
+	public void testDexArgumentsAvailable() {
+		Class<?> dexArgumentsClass = loadDexArgumentsClass();
+		
+		try {
+			dexArgumentsClass.getDeclaredField(DexWrapper.DEX_ARGUMENTS_FIELD_OUT_NAME);
+			dexArgumentsClass.getDeclaredField(DexWrapper.DEX_ARGUMENTS_FIELD_JAR_OUTPUT);
+			dexArgumentsClass.getDeclaredField(DexWrapper.DEX_ARGUMENTS_FIELD_FILES_NAMES);
+			dexArgumentsClass.getDeclaredField(DexWrapper.DEX_ARGUMENTS_FIELD_VERBOSE);
+			dexArgumentsClass.getDeclaredField(DexWrapper.DEX_ARGUMENTS_FIELD_FORCE_JUMBO);
+			dexArgumentsClass.getDeclaredField(DexWrapper.DEX_ARGUMENTS_FIELD_MULTI_DEX);
+			dexArgumentsClass.getDeclaredField(DexWrapper.DEX_ARGUMENTS_FIELD_MAIN_DEX_LIST_FILE);
+			dexArgumentsClass.getDeclaredField(DexWrapper.DEX_ARGUMENTS_FIELD_MINIMAL_MAIN_DEX);
+		} catch (SecurityException e) {
+			fail(e.getLocalizedMessage());
+	    } catch (NoSuchFieldException e) {
+	    	fail(e.getLocalizedMessage());
+	    }
+	}
+	
+	private Class<?> loadDexArgumentsClass() {
+		URLClassLoader loader = getSdkClassLoader();
+		try {
+			return loader.loadClass(DexWrapper.DEX_ARGS);
+		} catch (SecurityException e) {
+			fail(e.getLocalizedMessage());
+		} catch(ClassNotFoundException e) {
+			fail(e.getLocalizedMessage());
+		}
+		
+		return null;
+	}
+	
+	private Class<?> loadMainDexClass() {
+		URLClassLoader loader = getSdkClassLoader();
+		try {
+			return loader.loadClass(DexWrapper.DEX_MAIN);
+		} catch (SecurityException e) {
+			fail(e.getLocalizedMessage());
+		} catch(ClassNotFoundException e) {
+			fail(e.getLocalizedMessage());
+		}
+		
+		return null;
+	}
+	
+	public URLClassLoader getSdkClassLoader() {
+		ProjectState projectState = Sdk.getProjectState(getProject());
+		assertNotNull(projectState);
+		
+		String dxLocation = projectState.getBuildToolInfo().getPath(BuildToolInfo.PathId.DX_JAR);
+		
+		File f = new File(dxLocation);	
+		URL url = null;
+		try {
+			url = f.toURI().toURL();
+		} catch(MalformedURLException malformedURLException) {
+			fail(malformedURLException.getLocalizedMessage());
+		}
+		
+		return new URLClassLoader(new URL[] { url }, DexWrapper.class.getClassLoader());
+	}
+}

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/build/DexWrapperTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/build/DexWrapperTest.java
@@ -20,16 +20,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
-import org.eclipse.andmore.internal.build.DexWrapper;
 import org.eclipse.andmore.internal.editors.layout.refactoring.AdtProjectTest;
 import org.eclipse.andmore.internal.sdk.ProjectState;
 import org.eclipse.andmore.internal.sdk.Sdk;
-import org.eclipse.core.resources.IProject;
 import org.junit.Test;
 
 import com.android.sdklib.BuildToolInfo;
@@ -50,7 +47,6 @@ public class DexWrapperTest extends AdtProjectTest {
 		Class<?> mainDexClass = loadMainDexClass();
 		
 		try {
-			mainDexClass.getDeclaredField(DexWrapper.DEX_MAIN_FIELD_OUTPUT_FUTURES);
 			mainDexClass.getDeclaredField(DexWrapper.DEX_MAIN_FIELD_OUTPUT_ARRAYS);
 			mainDexClass.getDeclaredField(DexWrapper.DEX_MAIN_FIELD_CLASSES_IN_MAIN_DEX);
 			mainDexClass.getDeclaredField(DexWrapper.DEX_MAIN_FIELD_OUTPUT_RESOURCES);

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/settings/MultiDexTest.java
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/src/org/eclipse/andmore/internal/settings/MultiDexTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.andmore.internal.settings;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+
+import org.eclipse.andmore.android.multidex.MultiDexManager;
+import org.eclipse.andmore.internal.editors.layout.refactoring.AdtProjectTest;
+import org.eclipse.core.resources.IProject;
+import org.junit.Test;
+
+/**
+ * Test case to see if enabling multi-dex is still working.
+ */
+
+public class MultiDexTest extends AdtProjectTest {
+	
+	@Test
+	public void testEnableMultiDex() {
+		IProject project = getProject();
+		
+		MultiDexManager.enableMultiDex(project, null);
+		assertTrue(MultiDexManager.isMultiDexEnabled(project));
+		
+		// find out if the --main-dex-list file has been created. The content can be modified manually by the user and does not require validation.
+		File mainDexListFile = MultiDexManager.getMainDexListFile(project);
+		assertNotNull(mainDexListFile);
+		assertTrue(mainDexListFile.exists());
+	}
+	
+	@Test
+	public void testDisableMultiDex() {
+		IProject project = getProject();
+		
+		MultiDexManager.disableMultiDex(project);
+		assertFalse(MultiDexManager.isMultiDexEnabled(project));
+	}
+}

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/build/DexWrapper.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/build/DexWrapper.java
@@ -42,10 +42,24 @@ import com.android.SdkConstants;
  */
 public final class DexWrapper {
 
-    private final static String DEX_MAIN = "com.android.dx.command.dexer.Main"; //$NON-NLS-1$
-    private final static String DEX_CONSOLE = "com.android.dx.command.DxConsole"; //$NON-NLS-1$
-    private final static String DEX_ARGS = "com.android.dx.command.dexer.Main$Arguments"; //$NON-NLS-1$
+    public final static String DEX_MAIN = "com.android.dx.command.dexer.Main"; //$NON-NLS-1$
+    public final static String DEX_CONSOLE = "com.android.dx.command.DxConsole"; //$NON-NLS-1$
+    public final static String DEX_ARGS = "com.android.dx.command.dexer.Main$Arguments"; //$NON-NLS-1$
 
+    public final static String DEX_MAIN_FIELD_OUTPUT_FUTURES = "dexOutputFutures"; //$NON-NLS-1$
+    public final static String DEX_MAIN_FIELD_OUTPUT_ARRAYS = "dexOutputArrays"; //$NON-NLS-1$
+    public final static String DEX_MAIN_FIELD_CLASSES_IN_MAIN_DEX = "classesInMainDex"; //$NON-NLS-1$
+    public final static String DEX_MAIN_FIELD_OUTPUT_RESOURCES = "outputResources"; //$NON-NLS-1$
+    
+    public final static String DEX_ARGUMENTS_FIELD_OUT_NAME = "outName"; //$NON-NLS-1$
+    public final static String DEX_ARGUMENTS_FIELD_JAR_OUTPUT = "jarOutput"; //$NON-NLS-1$
+    public final static String DEX_ARGUMENTS_FIELD_FILES_NAMES = "fileNames"; //$NON-NLS-1$
+    public final static String DEX_ARGUMENTS_FIELD_VERBOSE = "verbose"; //$NON-NLS-1$
+    public final static String DEX_ARGUMENTS_FIELD_FORCE_JUMBO = "forceJumbo"; //$NON-NLS-1$
+    public final static String DEX_ARGUMENTS_FIELD_MULTI_DEX = "multiDex"; //$NON-NLS-1$
+    public final static String DEX_ARGUMENTS_FIELD_MAIN_DEX_LIST_FILE = "mainDexListFile"; //$NON-NLS-1$
+    public final static String DEX_ARGUMENTS_FIELD_MINIMAL_MAIN_DEX = "minimalMainDex"; //$NON-NLS-1$
+    
     private final static String MAIN_RUN = "run"; //$NON-NLS-1$
 
     private Method mRunMethod;
@@ -99,20 +113,20 @@ public final class DexWrapper {
                 // now get the fields/methods we need
                 mRunMethod = mainClass.getMethod(MAIN_RUN, argClass);
                 
-                mDexOutputFutures = mainClass.getDeclaredField("dexOutputFutures");
-                mDexOutputArrays = mainClass.getDeclaredField("dexOutputArrays");
-                mClassesInMainDex = mainClass.getDeclaredField("classesInMainDex");
-                mOutputResources = mainClass.getDeclaredField("outputResources");
+                mDexOutputFutures = mainClass.getDeclaredField(DEX_MAIN_FIELD_OUTPUT_FUTURES);
+                mDexOutputArrays = mainClass.getDeclaredField(DEX_MAIN_FIELD_OUTPUT_ARRAYS);
+                mClassesInMainDex = mainClass.getDeclaredField(DEX_MAIN_FIELD_CLASSES_IN_MAIN_DEX);
+                mOutputResources = mainClass.getDeclaredField(DEX_MAIN_FIELD_OUTPUT_RESOURCES);
                 
                 mArgConstructor = argClass.getConstructor();
-                mArgOutName = argClass.getField("outName"); //$NON-NLS-1$
-                mArgJarOutput = argClass.getField("jarOutput"); //$NON-NLS-1$
-                mArgFileNames = argClass.getField("fileNames"); //$NON-NLS-1$
-                mArgVerbose = argClass.getField("verbose"); //$NON-NLS-1$
-                mArgForceJumbo = argClass.getField("forceJumbo"); //$NON-NLS-1$
-                mArgMultiDex = argClass.getField("multiDex"); //$NON-NLS-1$
-                mArgMainDexListFile = argClass.getField("mainDexListFile");
-                mArgMinimalMainDex = argClass.getField("minimalMainDex");
+                mArgOutName = argClass.getField(DEX_ARGUMENTS_FIELD_OUT_NAME); //$NON-NLS-1$
+                mArgJarOutput = argClass.getField(DEX_ARGUMENTS_FIELD_JAR_OUTPUT); //$NON-NLS-1$
+                mArgFileNames = argClass.getField(DEX_ARGUMENTS_FIELD_FILES_NAMES); //$NON-NLS-1$
+                mArgVerbose = argClass.getField(DEX_ARGUMENTS_FIELD_VERBOSE); //$NON-NLS-1$
+                mArgForceJumbo = argClass.getField(DEX_ARGUMENTS_FIELD_FORCE_JUMBO); //$NON-NLS-1$
+                mArgMultiDex = argClass.getField(DEX_ARGUMENTS_FIELD_MULTI_DEX); //$NON-NLS-1$
+                mArgMainDexListFile = argClass.getField(DEX_ARGUMENTS_FIELD_MAIN_DEX_LIST_FILE);
+                mArgMinimalMainDex = argClass.getField(DEX_ARGUMENTS_FIELD_MINIMAL_MAIN_DEX);
 
                 mConsoleOut = consoleClass.getField("out"); //$NON-NLS-1$
                 mConsoleErr = consoleClass.getField("err"); //$NON-NLS-1$

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/build/DexWrapper.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/build/DexWrapper.java
@@ -113,7 +113,11 @@ public final class DexWrapper {
                 // now get the fields/methods we need
                 mRunMethod = mainClass.getMethod(MAIN_RUN, argClass);
                 
-                mDexOutputFutures = mainClass.getDeclaredField(DEX_MAIN_FIELD_OUTPUT_FUTURES);
+                try {
+                	// this field is not required when it is not yet available in Main.
+                	mDexOutputFutures = mainClass.getDeclaredField(DEX_MAIN_FIELD_OUTPUT_FUTURES);
+                } catch (Exception e) {}
+                
                 mDexOutputArrays = mainClass.getDeclaredField(DEX_MAIN_FIELD_OUTPUT_ARRAYS);
                 mClassesInMainDex = mainClass.getDeclaredField(DEX_MAIN_FIELD_CLASSES_IN_MAIN_DEX);
                 mOutputResources = mainClass.getDeclaredField(DEX_MAIN_FIELD_OUTPUT_RESOURCES);
@@ -184,13 +188,16 @@ public final class DexWrapper {
      * @throws Exception
      */
     private synchronized void resetDexMain() throws Exception {
-    	assert mDexOutputFutures != null;
     	assert mDexOutputArrays != null;
     	assert mClassesInMainDex != null;
     	assert mOutputResources != null;
     	
-    	if(!mDexOutputFutures.isAccessible()) {
-    		mDexOutputFutures.setAccessible(true);
+    	if(mDexOutputFutures != null) { // not required when not available
+	    	if(!mDexOutputFutures.isAccessible()) {
+	    		mDexOutputFutures.setAccessible(true);
+	    	}
+	    	
+	    	mDexOutputFutures.set(null, new ArrayList<Future<byte[]>>());
     	}
     	
     	if(!mDexOutputArrays.isAccessible()) {
@@ -204,8 +211,7 @@ public final class DexWrapper {
     	if(!mOutputResources.isAccessible()) {
     		mOutputResources.setAccessible(true);
     	}
-
-        mDexOutputFutures.set(null, new ArrayList<Future<byte[]>>());
+    	
         mDexOutputArrays.set(null, new ArrayList<byte[]>());
         mClassesInMainDex.set(null, null);
         mOutputResources.set(null, null);

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/project/ExportHelper.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/project/ExportHelper.java
@@ -273,11 +273,14 @@ public final class ExportHelper {
 
             helper.executeDx(javaProject, dxInput, dexFile.getAbsolutePath());
 
-            // Step 3. Final package
-
+            // Step 3. Gather dex files
+            List<File> dexFiles = helper.listDexFiles(javaProject);
+            
+            // Step 4. Final package
+            
             helper.finalPackage(
                     resourceFile.getAbsolutePath(),
-                    dexFile.getAbsolutePath(),
+                    dexFiles,
                     outputFile.getAbsolutePath(),
                     libProjects,
                     key,


### PR DESCRIPTION
Signed-off-by: Thys ten Veldhuis <t.tenveldhuis@gmail.com>

Added basic support for multi-dex. You can enable it by going to 

*Project > Properties > Android > General* and enabling the 'Enable MultiDex support' checkbox. This then adds two properties to the project.properties file:

> multidex.enabled=true
> multidex.main-dex-list=main-dex-list.txt

Enabling the checkbox also copies the *main-dex-list.txt* file so the user can specify which classes to include in the classes.dex which is automatically loaded before `MultiDex.install` is executed.