### PR TITLE
Update the build to use MARS and tycho 0.23.1

### DIFF
--- a/andmore-core/plugins/android.macosx/pom.xml
+++ b/andmore-core/plugins/android.macosx/pom.xml
@@ -23,11 +23,6 @@
 						<environment>
 							<os>macosx</os>
 							<ws>cocoa</ws>
-							<arch>x86</arch>
-						</environment>
-						<environment>
-							<os>macosx</os>
-							<ws>cocoa</ws>
 							<arch>x86_64</arch>
 						</environment>
 					</environments>

--- a/android-core/plugins/org.eclipse.andmore/andmore.target
+++ b/android-core/plugins/org.eclipse.andmore/andmore.target
@@ -17,11 +17,11 @@
 <unit id="org.eclipse.emf.common.ui.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.codegen.ui.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.wb.core.xml.feature.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/releases/luna"/>
+<repository location="http://download.eclipse.org/releases/mars"/>
 </location>
 <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.datatools.sdk.feature.feature.group" version="1.12.0.v201406061321-7PB21FEpPZQXdcX0z-_yMM0Hfz0w"/>
-<repository location="http://download.eclipse.org/releases/luna"/>
+<repository location="http://download.eclipse.org/releases/mars"/>
 </location>
 <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.sequoyah.vnc.feature.feature.group" version="2.1.0.N20120718-0509"/>
@@ -35,11 +35,11 @@
 </location>
 <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.mat.feature.feature.group" version="1.4.0.201406041413"/>
-<repository location="http://download.eclipse.org/releases/luna"/>
+<repository location="http://archive.eclipse.org/mat/1.4/update-site/"/>
 </location>
 <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/releases/luna"/>
+<repository location="http://download.eclipse.org/releases/mars"/>
 </location>
 <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.apache.commons.net.source" version="1.4.1.v200905122237"/>

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,8 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>0.22.0</tycho-version>
-		<platform-version-name>indigo</platform-version-name>
-		<eclipse-site>http://download.eclipse.org/releases/luna/</eclipse-site>
+		<tycho-version>0.23.1</tycho-version>
+		<eclipse-site>http://download.eclipse.org/releases/mars/</eclipse-site>
 		<orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20140114142710/repository</orbit-site>
 		<sequoyah-site>http://download.eclipse.org/sequoyah/updates/2.1/</sequoyah-site>
 		<m2e-update-site>http://download.eclipse.org/technology/m2e/releases/</m2e-update-site>
@@ -24,7 +23,7 @@
 			<url>${sequoyah-site}</url>
 		</repository>
 		<repository>
-			<id>helios</id>
+			<id>eclipse</id>
 			<layout>p2</layout>
 			<url>${eclipse-site}</url>
 		</repository>
@@ -117,6 +116,12 @@
 	</build>
 
 	<profiles>
+		<profile>
+			<id>luna</id>
+			<properties>
+				<eclipse-site>http://download.eclipse.org/releases/luna/</eclipse-site>
+			</properties>
+		</profile>
 		<profile>
 			<id>findbugs</id>
 			<build>

--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,6 @@
 						<environment>
 							<os>macosx</os>
 							<ws>cocoa</ws>
-							<arch>x86</arch>
-						</environment>
-						<environment>
-							<os>macosx</os>
-							<ws>cocoa</ws>
 							<arch>x86_64</arch>
 						</environment>
 						<environment>


### PR DESCRIPTION
Needed to remove the Mac OSX 32 bit support as that is no longer supported by Mars and the eclipse platform.