### PR TITLE
[459574] Migrate Build to use the CBI

### DIFF
--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>proteus-parent</name>
+	<name>andmore-parent</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,9 @@
 					<plugin>
 						<groupId>org.eclipse.cbi.maven.plugins</groupId>
 						<artifactId>eclipse-jarsigner-plugin</artifactId>
+						<configuration>
+							<excludeInnerJars>true</excludeInnerJars>
+						</configuration>
 						<executions>
 							<execution>
 								<id>sign</id>

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,38 @@
 	<groupId>org.eclipse.andmore</groupId>
 	<artifactId>andmore-parent</artifactId>
 	<version>0.5.0-SNAPSHOT</version>
+	<name>Andmore Parent</name>
 	<packaging>pom</packaging>
 
+	<url>https://eclipse.org/andmore</url>
+
+	<organization>
+		<name>Eclipse Foundation</name>
+		<url>http://eclipse.org</url>
+	</organization>
+
+	<mailingLists>
+		<mailingList>
+			<name>andmore-dev Mailing List</name>
+			<post>andmore-dev@eclipse.org</post>
+			<subscribe>https://dev.eclipse.org/mailman/listinfo/andmore-dev</subscribe>
+			<unsubscribe>https://dev.eclipse.org/mailman/listinfo/andmore-dev</unsubscribe>
+			<archive>http://dev.eclipse.org/mhonarc/lists/andmore-dev</archive>
+		</mailingList>
+	</mailingLists>
+
+	<issueManagement>
+		<url>https://bugs.eclipse.org/bugs/buglist.cgi?query_format=advanced;product=Andmore;classification=Tools</url>
+		<system>Bugzilla</system>
+	</issueManagement>
+
+	<ciManagement>
+		<system>Hudson</system>
+		<url>https://hudson.eclipse.org/andmore</url>
+	</ciManagement>
+
 	<properties>
-		<tycho-version>0.23.1</tycho-version>
+		<tycho-version>0.24.0</tycho-version>
 		<eclipse-site>http://download.eclipse.org/releases/mars/</eclipse-site>
 		<orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20140114142710/repository</orbit-site>
 		<sequoyah-site>http://download.eclipse.org/sequoyah/updates/2.1/</sequoyah-site>
@@ -44,16 +72,56 @@
 		</repository>
 	</repositories>
 
+	<pluginRepositories>
+		<pluginRepository>
+			<id>cbi-releases</id>
+			<url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>cbi-snapshots</id>
+			<url>https://repo.eclipse.org/content/repositories/cbi-snapshots/</url>
+		</pluginRepository>
+	</pluginRepositories>
+
+	<distributionManagement>
+		<repository>
+			<id>repo.eclipse.org</id>
+			<name>Andmore Maven Repository - Releases</name>
+			<url>https://repo.eclipse.org/content/repositories/andmore-releases/</url>
+		</repository>
+		<snapshotRepository>
+			<id>repo.eclipse.org</id>
+			<name>Andmore Maven Repository - Snapshots</name>
+			<url>https://repo.eclipse.org/content/repositories/andmore-snapshots/</url>
+			<uniqueVersion>true</uniqueVersion>
+		</snapshotRepository>
+	</distributionManagement>
+
 	<modules>
 		<module>android-core</module>
 		<module>andmore-core</module>
 	</modules>
 
-
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-maven-plugin</artifactId>
+					<version>${tycho-version}</version>
+					<extensions>true</extensions>
+				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>target-platform-configuration</artifactId>
+					<version>${tycho-version}</version>
+				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-p2-plugin</artifactId>
+					<version>${tycho-version}</version>
+				</plugin>
 				<plugin>
 					<groupId>org.eclipse.tycho.extras</groupId>
 					<artifactId>tycho-source-feature-plugin</artifactId>
@@ -64,13 +132,32 @@
 					<artifactId>tycho-document-bundle-plugin</artifactId>
 					<version>${tycho-version}</version>
 				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho.extras</groupId>
+					<artifactId>tycho-pack200a-plugin</artifactId>
+					<version>${tycho-version}</version>
+				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho.extras</groupId>
+					<artifactId>tycho-pack200b-plugin</artifactId>
+					<version>${tycho-version}</version>
+				</plugin>
+				<plugin>
+					<groupId>org.eclipse.cbi.maven.plugins</groupId>
+					<artifactId>eclipse-jarsigner-plugin</artifactId>
+					<version>1.1.2</version>
+				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>findbugs-maven-plugin</artifactId>
+					<version>3.0.0</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-maven-plugin</artifactId>
-				<version>${tycho-version}</version>
 				<extensions>true</extensions>
 			</plugin>
 			<plugin>
@@ -80,7 +167,6 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>target-platform-configuration</artifactId>
-				<version>${tycho-version}</version>
 				<configuration>
 					<resolver>p2</resolver>
 					<environments>
@@ -129,7 +215,6 @@
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>findbugs-maven-plugin</artifactId>
-						<version>3.0.0</version>
 						<configuration>
 							<findbugsXmlOutput>true</findbugsXmlOutput>
 							<failOnError>false</failOnError>
@@ -142,6 +227,75 @@
 								</goals>
 							</execution>
 						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>sign</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>target-platform-configuration</artifactId>
+						<configuration>
+							<includePackedArtifacts>true</includePackedArtifacts>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho.extras</groupId>
+						<artifactId>tycho-pack200a-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>pack200-normalize</id>
+								<goals>
+									<goal>normalize</goal>
+								</goals>
+								<phase>verify</phase>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.cbi.maven.plugins</groupId>
+						<artifactId>eclipse-jarsigner-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>sign</id>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<phase>verify</phase>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho.extras</groupId>
+						<artifactId>tycho-pack200b-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>pack200-pack</id>
+								<goals>
+									<goal>pack</goal>
+								</goals>
+								<phase>verify</phase>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-p2-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>p2-metadata</id>
+								<goals>
+									<goal>p2-metadata</goal>
+								</goals>
+								<phase>verify</phase>
+							</execution>
+						</executions>
+						<configuration>
+							<defaultP2Metadata>false</defaultP2Metadata>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
The parent pom.xml is updated to support JAR signing and deployment to
Nexus. Tycho is updated to the latest 0.24.0 version.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=459574
Signed-off-by: Kaloyan Raev <kaloyan.r@zend.com>