### PR TITLE
Add pref page entry for PreferenceInitializer.ATTR_SELECTED_DEBUG_PORT

### DIFF
--- a/android-core/plugins/org.eclipse.andmore.ddms/src/org/eclipse/andmore/ddms/i18n/Messages.java
+++ b/android-core/plugins/org.eclipse.andmore.ddms/src/org/eclipse/andmore/ddms/i18n/Messages.java
@@ -96,6 +96,7 @@ public class Messages extends NLS {
 	public static String PreferencePage_Adbhost_value;
 	public static String PreferencePage_Assert;
 	public static String PreferencePage_Base_Local_Debugger_Port;
+	public static String PreferencePage_Selected_Debugger_Port;
 	public static String PreferencePage_Debug;
 	public static String PreferencePage_Error;
 	public static String PreferencePage_Heap_Updates_Enabled_Default;

--- a/android-core/plugins/org.eclipse.andmore.ddms/src/org/eclipse/andmore/ddms/i18n/messages.properties
+++ b/android-core/plugins/org.eclipse.andmore.ddms/src/org/eclipse/andmore/ddms/i18n/messages.properties
@@ -98,6 +98,7 @@ PreferencePage_Info=Info
 PreferencePage_Logging_Level=Logging Level
 PreferencePage_Open_Eclipse=Open in Eclipse
 PreferencePage_Save_Disk=Save to disk
+PreferencePage_Selected_Debugger_Port=Selected debug port
 PreferencePage_Thread_Status_Refresh_Interval=Thread status refresh interval (seconds):
 PreferencePage_Thread_Updates_Enabled_By_Default=Thread updates enabled by default
 PreferencePage_Use_Adbhost=Use ADBHOST

--- a/android-core/plugins/org.eclipse.andmore.ddms/src/org/eclipse/andmore/ddms/preferences/PreferencePage.java
+++ b/android-core/plugins/org.eclipse.andmore.ddms/src/org/eclipse/andmore/ddms/preferences/PreferencePage.java
@@ -58,6 +58,11 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		ife.setValidRange(1024, 32767);
 		addField(ife);
 
+		ife = new IntegerFieldEditor(PreferenceInitializer.ATTR_SELECTED_DEBUG_PORT,
+				Messages.PreferencePage_Selected_Debugger_Port, getFieldEditorParent());
+		ife.setValidRange(1024, 32767);
+		addField(ife);
+
 		BooleanFieldEditor bfe;
 
 		bfe = new BooleanFieldEditor(PreferenceInitializer.ATTR_DEFAULT_THREAD_UPDATE,


### PR DESCRIPTION
I discovered that launching a second instance of Eclipse with Andmore installed would fail, this adds a pref page entry to configure the port to avoid duplication.