### PR TITLE
[509663] Add support for aapt --no-version-vectors option.

### DIFF
--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/build/BuildHelper.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/build/BuildHelper.java
@@ -113,7 +113,7 @@ public class BuildHelper {
 
     private static final String MULTIDEX_ENABLED_PROPERTY = "multidex.enabled";
     private static final String MULTIDEX_MAIN_DEX_LIST_PROPERTY = "multidex.main-dex-list";
-        
+    
     @NonNull
     private final ProjectState mProjectState;
     @NonNull
@@ -957,7 +957,9 @@ public class BuildHelper {
         if (aaptCommand.equals(COMMAND_PACKAGE)) {
             commandArray.add("-f");          //$NON-NLS-1$
             commandArray.add("--no-crunch"); //$NON-NLS-1$
-
+            if (mProjectState.isNoVersionVectors()) {
+            	commandArray.add("--no-version-vectors"); //$NON-NLS-1$	
+            }
             // if more than one res, this means there's a library (or more) and we need
             // to activate the auto-add-overlay
             if (osResPaths.size() > 1) {

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/properties/AndroidPropertyPage.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/properties/AndroidPropertyPage.java
@@ -50,6 +50,8 @@ public class AndroidPropertyPage extends PropertyPage {
     private IProject mProject;
     private SdkTargetSelector mSelector;
     private Button mIsLibrary;
+    private Button mNoVersionVectors;
+    
     // APK-SPLIT: This is not yet supported, so we hide the UI
 //    private Button mSplitByDensity;
     private LibraryProperties mLibraryDependencies;
@@ -89,6 +91,14 @@ public class AndroidPropertyPage extends PropertyPage {
 
         mIsLibrary = new Button(libraryGroup, SWT.CHECK);
         mIsLibrary.setText("Is Library");
+        
+        Group optionsGroup = new Group(top, SWT.NONE);
+        optionsGroup.setLayoutData(new GridData(GridData.FILL_BOTH));
+        optionsGroup.setLayout(new GridLayout(1, false));
+        optionsGroup.setText("Other Options");
+
+        mNoVersionVectors = new Button(optionsGroup, SWT.CHECK);
+        mNoVersionVectors.setText("--no-version-vectors");
 
         mLibraryDependencies = new LibraryProperties(libraryGroup);
 
@@ -133,7 +143,11 @@ public class AndroidPropertyPage extends PropertyPage {
                         Boolean.toString(mIsLibrary.getSelection()));
                 mustSaveProp = true;
             }
-
+            if (state == null || mNoVersionVectors.getSelection() != state.isNoVersionVectors()) {
+                mPropertiesWorkingCopy.setProperty(ProjectState.NO_VERSION_VECTORS_PROPERTY,
+                        Boolean.toString(mNoVersionVectors.getSelection()));
+                mustSaveProp = true;            	
+            }
             if (mLibraryDependencies.save()) {
                 mustSaveProp = true;
             }
@@ -178,6 +192,7 @@ public class AndroidPropertyPage extends PropertyPage {
             }
 
             mIsLibrary.setSelection(state.isLibrary());
+            mNoVersionVectors.setSelection(state.isNoVersionVectors());
             mLibraryDependencies.setContent(state, mPropertiesWorkingCopy);
         }
 

--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/sdk/ProjectState.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/sdk/ProjectState.java
@@ -57,6 +57,14 @@ import java.util.regex.Matcher;
  *
  */
 public final class ProjectState {
+	
+    /**
+     * The name of the property to enable the --no-version-vectors aapt option
+     * when packaging the resources. This constant should propably rather go to
+     * ProjectProperties, but the library that contains it is not included 
+     * in andmore as source code.
+     */
+    public static final String NO_VERSION_VECTORS_PROPERTY = "no-version-vectors.enabled";
 
     /**
      * A class that represents a library linked to a project.
@@ -380,6 +388,17 @@ public final class ProjectState {
         String value = mProperties.getProperty(ProjectProperties.PROPERTY_LIBRARY);
         return value != null && Boolean.valueOf(value);
     }
+    
+    /**
+     * Determines whether aapt should use the --no-version-vectors
+     * option in addition to other command line parameters.
+     * 
+     * @return True, if the corresponding project property is set to true.
+     */
+    public boolean isNoVersionVectors() {
+        return Boolean.parseBoolean(mProperties.getProperty(NO_VERSION_VECTORS_PROPERTY));
+    }
+    
 
     /**
      * Returns whether the project depends on one or more libraries.


### PR DESCRIPTION
Setting --no-version-vectors is necessary when using newer versions
(e.g. 25.1.0) of the appcompat library to target older Android devices.
If this flag is not set during the packaging, older devices will not be
able to access Android resource files properly. This results in app
crashes upon startup due to seemingly missing resources.

This commit extends the andmore user interface to include a check box in
the project-specific Android properties page which enables the user to
add the --no-version-vectors option during aapt runs. The value of the
check box is stored in the project.properties file and picked up by the
build helper when running aapt. If the properties file does not contain
the new property, the default is to not add the option during builds in
order to avoid side effects.

![image](https://cloud.githubusercontent.com/assets/16239218/21389129/4728afc4-c780-11e6-9b0a-76d60c7cc8b6.png)
