### PR TITLE
[484566] Fix NPE in BaseBuilder when property file is missing.

### DIFF
--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/build/builders/BaseBuilder.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/build/builders/BaseBuilder.java
@@ -320,10 +320,16 @@ public abstract class BaseBuilder extends IncrementalProjectBuilder {
         if (projectState == null) {
             projectState = Sdk.getProjectState(javaProject.getProject());
         }
-
+        
+        // the project state can still be null, 
+        // e.g. if there is no project.properties file
+        if (projectState == null) {
+        	throw new AbortBuildException();
+        }
+        
         // get the target for the project
-        IAndroidTarget target = projectState.getTarget();
-
+        IAndroidTarget target = projectState.getTarget();        	
+        
         if (target == null) {
             throw new AbortBuildException();
         }


### PR DESCRIPTION
When a project does not contain a project.poperties file, the
BaseBuilder will run into a NullPointerException. This change will
prevent the exception and abort the build. 

Note that this does not fix the new project wizard problem that is the
root cause of having an invalid project setup in the first place.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=484566
Signed-off-by: Marcus Handte <handte@locoslab.com>