### PR TITLE
[509666] Fix NPE in visual editor that causes load failures.

### DIFF
--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/editors/layout/configuration/ConfigurationMatcher.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/editors/layout/configuration/ConfigurationMatcher.java
@@ -454,22 +454,25 @@ public class ConfigurationMatcher {
 
             List<Locale> localeList = mConfigChooser.getLocaleList();
             final int count = localeList.size();
+            // if no locale match the current local locale, it's likely that it is
+            // the default one which is the last one.
+            int bestMatch = count - 1;
             for (int l = 0; l < count; l++) {
                 Locale locale = localeList.get(l);
                 LocaleQualifier localeQ = locale.locale;
-
-                // there's always a ##/Other or ##/Any (which is the same, the region
-                // contains FAKE_REGION_VALUE). If we don't find a perfect region match
-                // we take the fake region. Since it's last in the list, this makes the
-                // test easy.
-                if (localeQ.getLanguage().equals(currentLanguage) && (localeQ.getRegion().equals(currentRegion) || localeQ.hasRegion())) { 
-                    return l;
+                if (localeQ.getLanguage().equals(currentLanguage)) {
+                	if (localeQ.hasRegion() && localeQ.getRegion().equals(currentRegion)) {
+                		// there will be no better match
+                        return l;                		
+                	} else {
+                		// this one is close, but maybe there is a complete match
+                		bestMatch = l;
+                	}
                 }
+                                
             }
 
-            // if no locale match the current local locale, it's likely that it is
-            // the default one which is the last one.
-            return count - 1;
+            return bestMatch;
         }
 
         return -1;


### PR DESCRIPTION
When a project contains locales without region, the visual editor will fail to load due to a NPE in the algorithm that guesses the best default locale. As a result, the user will get a "no root view" message.

This change modifies the selection algorithm of the ConfigurationMatcher to either return a full language and region match or to return the last matching language setting without causing a NPE when the region is null. 

The only side effect I can see is that it will fully traverse the list if there is no full match instead of aborting earlier.  However, my feeling is that the resulting "loss of performance" is not noticeable whereas the NPE clearly is.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=509666
Signed-off-by: Marcus Handte handte@locoslab.com

![bildschirmfoto 2016-12-23 um 10 06 15](https://cloud.githubusercontent.com/assets/16239218/21450777/1ae98156-c8fa-11e6-8902-da02d6d42359.png)