### PR TITLE
[509683] Set execution environment in NDK plugin manifest.

### DIFF
--- a/android-core/plugins/org.eclipse.andmore.ndk/META-INF/MANIFEST.MF
+++ b/android-core/plugins/org.eclipse.andmore.ndk/META-INF/MANIFEST.MF
@@ -26,3 +26,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.andmore.ddms
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6


### PR DESCRIPTION
The @Override statments that refer to interfaces require at least 1.6 as
execution environment. This change sets the missing require statement in
the plugin manifest.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=509683
Signed-off-by: Marcus Handte <handte@locoslab.com>