### PR TITLE
please fix a bug 

### DIFF
--- a/andmore-core/features/basic/feature.xml
+++ b/andmore-core/features/basic/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.andmore.android.basic.feature"
       label="%feature.label"
-      version="0.5.1.qualifier"
+      version="0.5.2.qualifier"
       provider-name="%feature.provider.name"
       plugin="org.eclipse.andmore.android.common"
       os="linux,macosx,win32"

--- a/andmore-core/features/basic/pom.xml
+++ b/andmore-core/features/basic/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/features/feature/feature.xml
+++ b/andmore-core/features/feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.andmore.android.feature"
       label="%feature.android.label"
-      version="0.5.1.qualifier"
+      version="0.5.2.qualifier"
       provider-name="%feature.android.provider.name"
       plugin="org.eclipse.andmore.android.product"
       os="linux,macosx,win32"

--- a/andmore-core/features/feature/pom.xml
+++ b/andmore-core/features/feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
   <groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/features/sign/feature.xml
+++ b/andmore-core/features/sign/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.andmore.sign.feature"
       label="%feature.label"
-      version="0.5.1.qualifier"
+      version="0.5.2.qualifier"
       provider-name="%feature.provider.name"
       plugin="org.eclipse.andmore.android.certmanager"
       os="linux,macosx,win32"

--- a/andmore-core/features/sign/pom.xml
+++ b/andmore-core/features/sign/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/android.codeutils/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/android.codeutils/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.codeutils;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.codeutils.CodeUtilsActivator
 Bundle-Vendor: %providerName
 Bundle-ActivationPolicy: lazy

--- a/andmore-core/plugins/android.codeutils/pom.xml
+++ b/andmore-core/plugins/android.codeutils/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/android.linux.x86/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/android.linux.x86/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.linux.x86;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.andmore.android
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/andmore-core/plugins/android.linux.x86/pom.xml
+++ b/andmore-core/plugins/android.linux.x86/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/android.linux.x86_64/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/android.linux.x86_64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.andmore.android.linux.x86_64;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Fragment-Host: org.eclipse.andmore.android
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/andmore-core/plugins/android.linux.x86_64/pom.xml
+++ b/andmore-core/plugins/android.linux.x86_64/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/android.macosx/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/android.macosx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.macosx;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.andmore.android
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/andmore-core/plugins/android.macosx/pom.xml
+++ b/andmore-core/plugins/android.macosx/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/android.win32.x86/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/android.win32.x86/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.andmore.android.win32.x86;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Fragment-Host: org.eclipse.andmore.android
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/andmore-core/plugins/android.win32.x86/pom.xml
+++ b/andmore-core/plugins/android.win32.x86/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/android.win32.x86_64/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/android.win32.x86_64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.andmore.android.win32.x86_64;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Fragment-Host: org.eclipse.andmore.android
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/andmore-core/plugins/android.win32.x86_64/pom.xml
+++ b/andmore-core/plugins/android.win32.x86_64/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/android/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/android/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.AndroidPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/andmore-core/plugins/android/pom.xml
+++ b/andmore-core/plugins/android/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/certmanager/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/certmanager/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.certmanager;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.certmanager.CertificateManagerActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/andmore-core/plugins/certmanager/pom.xml
+++ b/andmore-core/plugins/certmanager/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/common/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.common;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.common.CommonPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/andmore-core/plugins/common/pom.xml
+++ b/andmore-core/plugins/common/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/db.core/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/db.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.db.core;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.db.core.DbCoreActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/andmore-core/plugins/db.core/pom.xml
+++ b/andmore-core/plugins/db.core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/db.devices/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/db.devices/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.db.devices;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.db.devices.DbDevicesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/andmore-core/plugins/db.devices/pom.xml
+++ b/andmore-core/plugins/db.devices/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/devices.services/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/devices.services/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.devices.services;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.devices.services.DeviceServicesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.andmore.android,

--- a/andmore-core/plugins/devices.services/pom.xml
+++ b/andmore-core/plugins/devices.services/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/emulator/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/emulator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.emulator;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.emulator.EmulatorPlugin
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/andmore-core/plugins/emulator/pom.xml
+++ b/andmore-core/plugins/emulator/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/handset/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/handset/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.handset;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.handset.HandsetPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.andmore.android,

--- a/andmore-core/plugins/handset/pom.xml
+++ b/andmore-core/plugins/handset/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/installer/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/installer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.installer;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.installer.InstallerPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/andmore-core/plugins/installer/pom.xml
+++ b/andmore-core/plugins/installer/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/launch/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/launch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.launch;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.launch.LaunchPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.andmore.android,

--- a/andmore-core/plugins/launch/pom.xml
+++ b/andmore-core/plugins/launch/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/logger.collector/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/logger.collector/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.logger.collector;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime
 Bundle-ActivationPolicy: lazy

--- a/andmore-core/plugins/logger.collector/pom.xml
+++ b/andmore-core/plugins/logger.collector/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/logger/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/logger/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Andmore Android Logger
 Bundle-SymbolicName: org.eclipse.andmore.android.logger;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.logger.internal.Activator
 Bundle-Vendor: Eclipse Andmore
 Export-Package: org.eclipse.andmore.android.logger

--- a/andmore-core/plugins/logger/pom.xml
+++ b/andmore-core/plugins/logger/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/mat/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/mat/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.mat;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.mat.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/andmore-core/plugins/mat/pom.xml
+++ b/andmore-core/plugins/mat/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/packaging.ui/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/packaging.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.packaging.ui;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.packaging.ui.PackagingUIPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.resources,

--- a/andmore-core/plugins/packaging.ui/pom.xml
+++ b/andmore-core/plugins/packaging.ui/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/remote.device/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/remote.device/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.remote;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.android.remote.RemoteDevicePlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/andmore-core/plugins/remote.device/pom.xml
+++ b/andmore-core/plugins/remote.device/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/snippets/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/snippets/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.codesnippets;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/andmore-core/plugins/snippets/pom.xml
+++ b/andmore-core/plugins/snippets/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/plugins/translation/META-INF/MANIFEST.MF
+++ b/andmore-core/plugins/translation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.android.translation;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.net,

--- a/andmore-core/plugins/translation/pom.xml
+++ b/andmore-core/plugins/translation/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.andmore</groupId>

--- a/andmore-core/pom.xml
+++ b/andmore-core/pom.xml
@@ -5,12 +5,12 @@
   <parent>
       <groupId>org.eclipse.andmore</groupId>
       <artifactId>andmore-parent</artifactId>
-      <version>0.5.1-SNAPSHOT</version>
+      <version>0.5.2-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.andmore</groupId>
   <artifactId>andmore-core</artifactId>
-  <version>0.5.1-SNAPSHOT</version>
+  <version>0.5.2-SNAPSHOT</version>
   <packaging>pom</packaging>
     
   

--- a/andmore-core/site/pom.xml
+++ b/andmore-core/site/pom.xml
@@ -10,13 +10,13 @@
 	<parent>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.andmore.repository</artifactId>
 	<packaging>eclipse-repository</packaging>
 
 	<name>Andmore Repository</name>
-	<version>0.5.1-SNAPSHOT</version>
+	<version>0.5.2-SNAPSHOT</version>
 
 </project>

--- a/android-core/features/org.eclipse.andmore.ddms/feature.xml
+++ b/android-core/features/org.eclipse.andmore.ddms/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.andmore.ddms.feature"
       label="Andmore Android DDMS"
-      version="0.5.1.qualifier"
+      version="0.5.2.qualifier"
       provider-name="Eclipse Andmore"
       plugin="org.eclipse.andmore.ddms"
       license-feature="org.eclipse.license"

--- a/android-core/features/org.eclipse.andmore.ddms/pom.xml
+++ b/android-core/features/org.eclipse.andmore.ddms/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
     	<build>
 		<plugins>

--- a/android-core/features/org.eclipse.andmore.gldebugger/feature.xml
+++ b/android-core/features/org.eclipse.andmore.gldebugger/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.andmore.gldebugger.feature"
       label="%feature.label"
-      version="0.5.1.qualifier"
+      version="0.5.2.qualifier"
       provider-name="%feature.provider.name"
       plugin="org.eclipse.andmore.gldebugger"
       license-feature="org.eclipse.license"

--- a/android-core/features/org.eclipse.andmore.gldebugger/pom.xml
+++ b/android-core/features/org.eclipse.andmore.gldebugger/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
     
     	<build>

--- a/android-core/features/org.eclipse.andmore.hierarchyviewer/feature.xml
+++ b/android-core/features/org.eclipse.andmore.hierarchyviewer/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.andmore.hierarchyviewer.feature"
       label="%feature.label"
-      version="0.5.1.qualifier"
+      version="0.5.2.qualifier"
       provider-name="%feature.provider.name"
       plugin="org.eclipse.andmore.hierarchyviewer"
       license-feature="org.eclipse.license"

--- a/android-core/features/org.eclipse.andmore.hierarchyviewer/pom.xml
+++ b/android-core/features/org.eclipse.andmore.hierarchyviewer/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
     
     	<build>

--- a/android-core/features/org.eclipse.andmore.ndk/feature.xml
+++ b/android-core/features/org.eclipse.andmore.ndk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.andmore.ndk.feature"
       label="%feature.label"
-      version="0.5.1.qualifier"
+      version="0.5.2.qualifier"
       provider-name="%feature.provider.name"
       plugin="org.eclipse.andmore.ndk"
       license-feature="org.eclipse.license"

--- a/android-core/features/org.eclipse.andmore.ndk/pom.xml
+++ b/android-core/features/org.eclipse.andmore.ndk/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
     
     	<build>

--- a/android-core/features/org.eclipse.andmore.package/feature.xml
+++ b/android-core/features/org.eclipse.andmore.package/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.andmore.package.feature"
       label="Andmore Package Feature (Incubating)"
-      version="0.5.1.qualifier"
+      version="0.5.2.qualifier"
       provider-name="Eclipse Andmore"
       plugin="org.eclipse.andmore.package"
       license-feature="org.eclipse.license"

--- a/android-core/features/org.eclipse.andmore.package/pom.xml
+++ b/android-core/features/org.eclipse.andmore.package/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/android-core/features/org.eclipse.andmore.traceview/feature.xml
+++ b/android-core/features/org.eclipse.andmore.traceview/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.andmore.traceview.feature"
       label="%feature.label"
-      version="0.5.1.qualifier"
+      version="0.5.2.qualifier"
       provider-name="%feature.provider.name"
       plugin="org.eclipse.andmore.traceview"
       license-feature="org.eclipse.license"

--- a/android-core/features/org.eclipse.andmore.traceview/pom.xml
+++ b/android-core/features/org.eclipse.andmore.traceview/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
     
     	<build>

--- a/android-core/features/org.eclipse.andmore/feature.xml
+++ b/android-core/features/org.eclipse.andmore/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.andmore.feature"
       label="%feature.label"
-      version="0.5.1.qualifier"
+      version="0.5.2.qualifier"
       provider-name="%feature.provider.name"
       plugin="org.eclipse.andmore"
       license-feature="org.eclipse.license"

--- a/android-core/features/org.eclipse.andmore/pom.xml
+++ b/android-core/features/org.eclipse.andmore/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/android-core/plugins/org.eclipse.andmore.base/META-INF/MANIFEST.MF
+++ b/android-core/plugins/org.eclipse.andmore.base/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Common Android Utilities
 Bundle-SymbolicName: org.eclipse.andmore.base;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.apache.httpcomponents.httpclient;bundle-version="4.1.3",

--- a/android-core/plugins/org.eclipse.andmore.base/pom.xml
+++ b/android-core/plugins/org.eclipse.andmore.base/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/android-core/plugins/org.eclipse.andmore.ddms/META-INF/MANIFEST.MF
+++ b/android-core/plugins/org.eclipse.andmore.ddms/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.andmore.ddms;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.ddms.DdmsPlugin
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/android-core/plugins/org.eclipse.andmore.ddms/pom.xml
+++ b/android-core/plugins/org.eclipse.andmore.ddms/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/android-core/plugins/org.eclipse.andmore.gldebugger/META-INF/MANIFEST.MF
+++ b/android-core/plugins/org.eclipse.andmore.gldebugger/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tracer for OpenGL ES
 Bundle-SymbolicName: org.eclipse.andmore.gldebugger;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.gltrace.GlTracePlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/android-core/plugins/org.eclipse.andmore.gldebugger/pom.xml
+++ b/android-core/plugins/org.eclipse.andmore.gldebugger/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/android-core/plugins/org.eclipse.andmore.hierarchyviewer/META-INF/MANIFEST.MF
+++ b/android-core/plugins/org.eclipse.andmore.hierarchyviewer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.andmore.hierarchyviewer;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.hierarchyviewer.HierarchyViewerPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/android-core/plugins/org.eclipse.andmore.hierarchyviewer/pom.xml
+++ b/android-core/plugins/org.eclipse.andmore.hierarchyviewer/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/META-INF/MANIFEST.MF
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Android Plugin Tests
 Bundle-SymbolicName: org.eclipse.andmore.integration.tests
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Vendor: Eclipse Andmore
 Fragment-Host: org.eclipse.andmore
 Require-Bundle: org.junit,

--- a/android-core/plugins/org.eclipse.andmore.integration.tests/pom.xml
+++ b/android-core/plugins/org.eclipse.andmore.integration.tests/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/android-core/plugins/org.eclipse.andmore.ndk/META-INF/MANIFEST.MF
+++ b/android-core/plugins/org.eclipse.andmore.ndk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Native Development Tools for Android
 Bundle-SymbolicName: org.eclipse.andmore.ndk;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.ndk.internal.Activator
 Bundle-Vendor: Eclipse Andmore
 Require-Bundle: org.eclipse.core.runtime,

--- a/android-core/plugins/org.eclipse.andmore.ndk/pom.xml
+++ b/android-core/plugins/org.eclipse.andmore.ndk/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/android-core/plugins/org.eclipse.andmore.overlay/META-INF/MANIFEST.MF
+++ b/android-core/plugins/org.eclipse.andmore.overlay/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ADT XML Overlay
 Bundle-SymbolicName: org.eclipse.andmore.overlay;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Vendor: Eclipse Andmore
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/android-core/plugins/org.eclipse.andmore.overlay/pom.xml
+++ b/android-core/plugins/org.eclipse.andmore.overlay/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/android-core/plugins/org.eclipse.andmore.package/META-INF/MANIFEST.MF
+++ b/android-core/plugins/org.eclipse.andmore.package/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.andmore.package;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Eclipse-BundleShape: dir

--- a/android-core/plugins/org.eclipse.andmore.package/pom.xml
+++ b/android-core/plugins/org.eclipse.andmore.package/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/android-core/plugins/org.eclipse.andmore.traceview/META-INF/MANIFEST.MF
+++ b/android-core/plugins/org.eclipse.andmore.traceview/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Traceview for Android
 Bundle-SymbolicName: org.eclipse.andmore.traceview;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-Activator: org.eclipse.andmore.traceview.TraceviewPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/android-core/plugins/org.eclipse.andmore.traceview/pom.xml
+++ b/android-core/plugins/org.eclipse.andmore.traceview/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
 
     <build>

--- a/android-core/plugins/org.eclipse.andmore/META-INF/MANIFEST.MF
+++ b/android-core/plugins/org.eclipse.andmore/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Core Development Tools for Android
 Bundle-SymbolicName: org.eclipse.andmore;singleton:=true
-Bundle-Version: 0.5.1.qualifier
+Bundle-Version: 0.5.2.qualifier
 Bundle-ClassPath: .,
  libs/sdkuilib.jar,
  libs/ninepatch.jar,

--- a/android-core/plugins/org.eclipse.andmore/pom.xml
+++ b/android-core/plugins/org.eclipse.andmore/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../../pom.xml</relativePath>
 		<groupId>org.eclipse.andmore</groupId>
 		<artifactId>andmore-core-parent</artifactId>
-		<version>0.5.1-SNAPSHOT</version>
+		<version>0.5.2-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/android-core/pom.xml
+++ b/android-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
       <groupId>org.eclipse.andmore</groupId>
       <artifactId>andmore-parent</artifactId>
-      <version>0.5.1-SNAPSHOT</version>
+      <version>0.5.2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.andmore</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.andmore</groupId>
 	<artifactId>andmore-parent</artifactId>
-	<version>0.5.1-SNAPSHOT</version>
+	<version>0.5.2-SNAPSHOT</version>
 	<name>Andmore Parent</name>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
sorry i'm unacquainted with EclipsePluginDevelop.I want your help.
when we import old 'ADT' project will cause a bug.
i think we should delete the .project file and use andmore Plugin to create .project file.
if we not delete .project file.
it will use exsist .project file.
like com.android.ide.eclipse.adt.ResourceManagerBuilder
but not found.
because we use andmore.